### PR TITLE
Only check repetition nesting

### DIFF
--- a/expandable-impl/src/repetition_stack.rs
+++ b/expandable-impl/src/repetition_stack.rs
@@ -17,6 +17,8 @@ pub(crate) fn check<Span>(
 where
     Span: Copy,
 {
+    // TODO(perf): we could avoid many allocations by storing the stack depth
+    // instead of the stack itself.
     let usages = substitution
         .iter()
         .flat_map(|e| collect_usages(e, &LameLinkedList::Nil));
@@ -30,7 +32,7 @@ where
                 span,
                 ..
             }) => {
-                if &stack != repetition_stack {
+                if stack.len() != repetition_stack.len() {
                     return Err(Error::InvalidRepetitionNesting {
                         metavariable_name: name.to_string(),
                         decl_span: *span,

--- a/expandable-impl/src/repetition_stack.rs
+++ b/expandable-impl/src/repetition_stack.rs
@@ -129,18 +129,17 @@ mod tests {
     }
 
     repetition_match_test! {
-        #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: \
-            InvalidRepetitionNesting { \
-                metavariable_name: \"a\", \
-                decl_span: (), \
-                usage_span: (), \
-                expected_nesting: [ZeroOrMore], \
-                got_nesting: [OneOrMore] \
-            }\
-        ")]
-        fn nonmatching_stack() {
+        fn nonmatching_stack_1() {
             {
                 ( @( @a:ident )* ) => { @( @a )+ }
+            }
+        }
+    }
+
+    repetition_match_test! {
+        fn nonmatching_stack_2() {
+            {
+                ( @( @( @( @a:ident )? )* )+ ) => { @( @( @( @a )* )? )+ }
             }
         }
     }

--- a/tests/ui/fail/bad_nesting_1.stderr
+++ b/tests/ui/fail/bad_nesting_1.stderr
@@ -1,5 +1,5 @@
-error: Metavariable `a` must be repeated with `?` nesting. It is repeated with `*`
- --> tests/ui/fail/bad_nesting_1.rs:4:33
+error: the matcher defines one repetition (`?`) for a but the transcriber uses no repetition
+ --> tests/ui/fail/bad_nesting_1.rs:5:10
   |
-4 |     ( $( $a:ident )? ) => { $( $a )* }
-  |                                 ^
+5 |         $a
+  |          ^

--- a/tests/ui/fail/bad_nesting_2.rs
+++ b/tests/ui/fail/bad_nesting_2.rs
@@ -1,8 +1,8 @@
 #[expandable::expr]
 #[allow(unused_macros)]
 macro_rules! bad_nesting_example {
-    ( $( $a:ident )? ) => {
-        $a
+    ( $( $( $( $a:ident, )*, )+, )? ) => {
+        $( $a )*
     };
 }
 

--- a/tests/ui/fail/bad_nesting_2.stderr
+++ b/tests/ui/fail/bad_nesting_2.stderr
@@ -1,0 +1,5 @@
+error: the matcher defines 3 repetitions (`?+*`) for a but the transcriber uses one repetition (`*`)
+ --> tests/ui/fail/bad_nesting_2.rs:5:13
+  |
+5 |         $( $a )*
+  |             ^

--- a/tests/ui/pass/repetition_nesting.rs
+++ b/tests/ui/pass/repetition_nesting.rs
@@ -1,0 +1,6 @@
+#[allow(unused_macros)]
+macro_rules! test {
+    ( $( $ident:ident )? ) => { $( $ident )* };
+}
+
+fn main() {}


### PR DESCRIPTION
I initially thought that the transcriber repetition stack must be equal to the matcher repetition stack, but it turns out that only the nesting value must be equal. In other words, this means that the following is a valid macro:

```rust
macro_rules! test {
    // Matched repetition stack: +?*
    ( $( $( $( $a:ident, )* )? )+ ) => {
        // Transcribed repetition stack: ***
        $( $( $( $a, )* )* )*
    }
}
```

In addition, the error message has been reworked. It's probably a bit too long, but I don't see how we can improve that.