### PR TITLE
Update README and crate docs to show 1.65 as MSRV, not 1.56

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ multiple macros are available:
 
 ## Minimal Supported Rust Version (MSRV), syntax support and stability
 
-_`expandable` supports Rust 1.56 and above. Bumping the MSRV is
+_`expandable` supports Rust 1.65 and above. Bumping the MSRV is
 considered a breaking change._
 
 Note that the embedded parser will support syntax that was introduced
-_after_ Rust 1.56.
+_after_ Rust 1.65.
 
 Adding support for newer syntax is _not_ considered a breaking change.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,11 +63,11 @@
 //!
 //! ## Minimal Supported Rust Version (MSRV), syntax support and stability
 //!
-//! _`expandable` supports Rust 1.56 and above. Bumping the MSRV is
+//! _`expandable` supports Rust 1.65 and above. Bumping the MSRV is
 //! considered a breaking change._
 //!
 //! Note that the embedded parser will support syntax that was introduced
-//! _after_ Rust 1.56.
+//! _after_ Rust 1.65.
 //!
 //! Adding support for newer syntax is _not_ considered a breaking change.
 //!


### PR DESCRIPTION
Based on the GitHub Actions config and the justfile, the tested MSRV appears to be 1.65, not 1.56 like the README says on the current `main` branch. I'm guessing the code is correct and the README just swapped the numbers by accident.