### PR TITLE
Add debug-only span

### DIFF
--- a/expandable-impl/src/expansion.rs
+++ b/expandable-impl/src/expansion.rs
@@ -276,7 +276,7 @@ mod tests {
         ( $test_name:ident { #[$kind:ident]( $( $matcher:tt )* ) => { $( $substitution:tt )* } $(;)? }) => {
             #[test]
             fn $test_name() {
-                let matcher: Vec<crate::TokenTree<()>> = quote! { $( $matcher )* };
+                let matcher: Vec<crate::TokenTree<_>> = quote! { $( $matcher )* };
                 let matcher = crate::matcher::TokenTree::from_generic(matcher).expect("Failed to generate `matcher::TokenTree`");
                 let bindings = crate::matcher::Matcher::from_generic(&matcher).expect("Failed to generate `matcher::Bindings`");
 

--- a/expandable-impl/src/grammar.rs
+++ b/expandable-impl/src/grammar.rs
@@ -266,6 +266,8 @@ token_description! {
         Terminal::QuestionMark => QuestionMark,
         /// The dollar sign (`$`).
         Terminal::Dollar => Dollar,
+        /// The pound sign (`#`).
+        Terminal::Pound => Pound,
 
         // Keywords
         /// The `as` keyword.

--- a/expandable-impl/src/lib.rs
+++ b/expandable-impl/src/lib.rs
@@ -134,6 +134,7 @@ mod grammar;
 mod list;
 mod matcher;
 mod repetition_stack;
+#[cfg(test)]
 mod span;
 mod states;
 mod substitution;

--- a/expandable-impl/src/lib.rs
+++ b/expandable-impl/src/lib.rs
@@ -134,6 +134,7 @@ mod grammar;
 mod list;
 mod matcher;
 mod repetition_stack;
+mod span;
 mod states;
 mod substitution;
 
@@ -238,25 +239,25 @@ pub struct TokenTree<Span> {
 
 #[cfg(test)]
 #[allow(non_snake_case, unused)]
-impl TokenTree<()> {
-    fn Terminal(t: Terminal) -> TokenTree<()> {
+impl<Span> TokenTree<Span> {
+    fn terminal(span: Span, t: Terminal) -> TokenTree<Span> {
         TokenTree {
             kind: TokenTreeKind::Terminal(t),
-            span: (),
+            span,
         }
     }
 
-    fn Parenthesed(i: Vec<TokenTree<()>>) -> TokenTree<()> {
+    fn parenthesed(span: Span, i: Vec<TokenTree<Span>>) -> TokenTree<Span> {
         TokenTree {
             kind: TokenTreeKind::Parenthesed(i),
-            span: (),
+            span,
         }
     }
 
-    fn CurlyBraced(i: Vec<TokenTree<()>>) -> TokenTree<()> {
+    fn curlyBraced(span: Span, i: Vec<TokenTree<Span>>) -> TokenTree<Span> {
         TokenTree {
             kind: TokenTreeKind::CurlyBraced(i),
-            span: (),
+            span,
         }
     }
 }

--- a/expandable-impl/src/lib.rs
+++ b/expandable-impl/src/lib.rs
@@ -306,6 +306,8 @@ pub enum Terminal {
     Semi,
     /// A times (`*`).
     Times,
+    /// A pound (`#`).
+    Pound,
 
     // Currently used keywords
     /// The `as` keyword.

--- a/expandable-impl/src/macros.rs
+++ b/expandable-impl/src/macros.rs
@@ -352,7 +352,7 @@ mod tests {
                                 "a",
                             ),
                         ),
-                        span: (),
+                        span: 0,
                     },
                     TokenTree {
                         kind: Terminal(
@@ -360,7 +360,7 @@ mod tests {
                                 "b",
                             ),
                         ),
-                        span: (),
+                        span: 1,
                     },
                     TokenTree {
                         kind: Terminal(
@@ -368,7 +368,7 @@ mod tests {
                                 "c",
                             ),
                         ),
-                        span: (),
+                        span: 2,
                     },
                     TokenTree {
                         kind: Terminal(
@@ -376,7 +376,7 @@ mod tests {
                                 "d",
                             ),
                         ),
-                        span: (),
+                        span: 3,
                     },
                 ]
             "#]],
@@ -394,13 +394,13 @@ mod tests {
                                 "a",
                             ),
                         ),
-                        span: (),
+                        span: 0,
                     },
                     TokenTree {
                         kind: Terminal(
                             Plus,
                         ),
-                        span: (),
+                        span: 1,
                     },
                     TokenTree {
                         kind: Terminal(
@@ -408,13 +408,13 @@ mod tests {
                                 "b",
                             ),
                         ),
-                        span: (),
+                        span: 2,
                     },
                     TokenTree {
                         kind: Terminal(
                             Dollar,
                         ),
-                        span: (),
+                        span: 3,
                     },
                     TokenTree {
                         kind: Parenthesed(
@@ -423,7 +423,7 @@ mod tests {
                                     kind: Terminal(
                                         Dollar,
                                     ),
-                                    span: (),
+                                    span: 5,
                                 },
                                 TokenTree {
                                     kind: Terminal(
@@ -431,13 +431,13 @@ mod tests {
                                             "test",
                                         ),
                                     ),
-                                    span: (),
+                                    span: 6,
                                 },
                                 TokenTree {
                                     kind: Terminal(
                                         Colon,
                                     ),
-                                    span: (),
+                                    span: 7,
                                 },
                                 TokenTree {
                                     kind: Terminal(
@@ -445,23 +445,23 @@ mod tests {
                                             "ident",
                                         ),
                                     ),
-                                    span: (),
+                                    span: 8,
                                 },
                             ],
                         ),
-                        span: (),
+                        span: 4,
                     },
                     TokenTree {
                         kind: Terminal(
                             Plus,
                         ),
-                        span: (),
+                        span: 9,
                     },
                     TokenTree {
                         kind: Terminal(
                             Times,
                         ),
-                        span: (),
+                        span: 10,
                     },
                 ]
             "#]],
@@ -479,13 +479,13 @@ mod tests {
                                 "a",
                             ),
                         ),
-                        span: (),
+                        span: 0,
                     },
                     TokenTree {
                         kind: Terminal(
                             Plus,
                         ),
-                        span: (),
+                        span: 1,
                     },
                     TokenTree {
                         kind: Terminal(
@@ -493,13 +493,13 @@ mod tests {
                                 "b",
                             ),
                         ),
-                        span: (),
+                        span: 2,
                     },
                     TokenTree {
                         kind: Terminal(
                             Dollar,
                         ),
-                        span: (),
+                        span: 3,
                     },
                     TokenTree {
                         kind: Parenthesed(
@@ -508,13 +508,13 @@ mod tests {
                                     kind: Terminal(
                                         Plus,
                                     ),
-                                    span: (),
+                                    span: 5,
                                 },
                                 TokenTree {
                                     kind: Terminal(
                                         Dollar,
                                     ),
-                                    span: (),
+                                    span: 6,
                                 },
                                 TokenTree {
                                     kind: Terminal(
@@ -522,13 +522,13 @@ mod tests {
                                             "c",
                                         ),
                                     ),
-                                    span: (),
+                                    span: 7,
                                 },
                                 TokenTree {
                                     kind: Terminal(
                                         Plus,
                                     ),
-                                    span: (),
+                                    span: 8,
                                 },
                                 TokenTree {
                                     kind: Terminal(
@@ -536,23 +536,23 @@ mod tests {
                                             "a",
                                         ),
                                     ),
-                                    span: (),
+                                    span: 9,
                                 },
                             ],
                         ),
-                        span: (),
+                        span: 4,
                     },
                     TokenTree {
                         kind: Terminal(
                             Plus,
                         ),
-                        span: (),
+                        span: 10,
                     },
                     TokenTree {
                         kind: Terminal(
                             QuestionMark,
                         ),
-                        span: (),
+                        span: 11,
                     },
                 ]
             "#]],

--- a/expandable-impl/src/macros.rs
+++ b/expandable-impl/src/macros.rs
@@ -3,307 +3,313 @@
 
 #[cfg(test)]
 macro_rules! quote {
-    (@inner, ( $( $tt:tt )* ) ) => {
-        $crate::TokenTree::Parenthesed(quote! { $( $tt )* })
+    (@inner $sb:expr, ( $( $tt:tt )* ) ) => {
+        $crate::TokenTree::parenthesed($sb.mk_span(), quote! { @with_sb $sb, $( $tt )* })
     };
 
-    (@inner, { $( $tt:tt )* } ) => {
-        $crate::TokenTree::CurlyBraced(quote! { $( $tt )* })
+
+    (@inner $sb:expr, { $( $tt:tt )* } ) => {
+        $crate::TokenTree::curlyBraced($sb.mk_span(), quote! { @with_sb $sb, $( $tt )* })
     };
 
-    (@inner, @) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Dollar)
+    (@inner $sb:expr, @) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Dollar)
     };
 
-    (@inner, :) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Colon)
+    (@inner $sb:expr, :) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Colon)
     };
 
-    (@inner, ?) => {
-        $crate::TokenTree::Terminal($crate::Terminal::QuestionMark)
+    (@inner $sb:expr, ?) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::QuestionMark)
     };
 
-    (@inner, +) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Plus)
+    (@inner $sb:expr, +) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Plus)
     };
 
-    (@inner, *) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Times)
+    (@inner $sb:expr, *) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Times)
     };
 
-    (@inner, =>) => {
-        $crate::TokenTree::Terminal($crate::Terminal::FatArrow)
+    (@inner $sb:expr, =>) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::FatArrow)
     };
 
-    (@inner, ;) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Semi)
+    (@inner $sb:expr, ;) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Semi)
     };
 
     // Keywords
-    (@inner, as) => {
-        $crate::TokenTree::Terminal($crate::Terminal::As)
+    (@inner $sb:expr, as) => {
+        $crate::TokenTree::terminal($sb.make_span(), $crate::Terminal::As)
     };
 
-    (@inner, break) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Break)
+    (@inner $sb:expr, break) => {
+        $crate::TokenTree::terminal($sb.make_span(), $crate::Terminal::Break)
     };
 
-    (@inner, const) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Const)
+    (@inner $sb:expr, const) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Const)
     };
 
-    (@inner, continue) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Continue)
+    (@inner $sb:expr, continue) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Continue)
     };
 
-    (@inner, crate) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Crate)
+    (@inner $sb:expr, crate) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Crate)
     };
 
-    (@inner, else) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Else)
+    (@inner $sb:expr, else) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Else)
     };
 
-    (@inner, enum) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Enum)
+    (@inner $sb:expr, enum) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Enum)
     };
 
-    (@inner, extern) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Extern)
+    (@inner $sb:expr, extern) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Extern)
     };
 
-    (@inner, false) => {
-        $crate::TokenTree::Terminal($crate::Terminal::False)
+    (@inner $sb:expr, false) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::False)
     };
 
-    (@inner, fn) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Fn)
+    (@inner $sb:expr, fn) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Fn)
     };
 
-    (@inner, for) => {
-        $crate::TokenTree::Terminal($crate::Terminal::For)
+    (@inner $sb:expr, for) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::For)
     };
 
-    (@inner, if) => {
-        $crate::TokenTree::Terminal($crate::Terminal::If)
+    (@inner $sb:expr, if) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::If)
     };
 
-    (@inner, impl) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Impl)
+    (@inner $sb:expr, impl) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Impl)
     };
 
-    (@inner, in) => {
-        $crate::TokenTree::Terminal($crate::Terminal::In)
+    (@inner $sb:expr, in) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::In)
     };
 
-    (@inner, let) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Let)
+    (@inner $sb:expr, let) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Let)
     };
 
-    (@inner, loop) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Loop)
+    (@inner $sb:expr, loop) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Loop)
     };
 
-    (@inner, match) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Match)
+    (@inner $sb:expr, match) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Match)
     };
 
-    (@inner, mod) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Mod)
+    (@inner $sb:expr, mod) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Mod)
     };
 
-    (@inner, move) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Move)
+    (@inner $sb:expr, move) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Move)
     };
 
-    (@inner, mut) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Mut)
+    (@inner $sb:expr, mut) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Mut)
     };
 
-    (@inner, pub) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Pub)
+    (@inner $sb:expr, pub) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Pub)
     };
 
-    (@inner, ref) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Ref)
+    (@inner $sb:expr, ref) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Ref)
     };
 
-    (@inner, return) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Return)
+    (@inner $sb:expr, return) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Return)
     };
 
-    (@inner, self) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Self_)
+    (@inner $sb:expr, self) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Self_)
     };
 
-    (@inner, Self) => {
-        $crate::TokenTree::Terminal($crate::Terminal::SelfUpper)
+    (@inner $sb:expr, Self) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::SelfUpper)
     };
 
-    (@inner, static) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Static)
+    (@inner $sb:expr, static) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Static)
     };
 
-    (@inner, struct) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Struct)
+    (@inner $sb:expr, struct) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Struct)
     };
 
-    (@inner, super) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Super)
+    (@inner $sb:expr, super) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Super)
     };
 
-    (@inner, trait) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Trait)
+    (@inner $sb:expr, trait) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Trait)
     };
 
-    (@inner, true) => {
-        $crate::TokenTree::Terminal($crate::Terminal::True)
+    (@inner $sb:expr, true) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::True)
     };
 
-    (@inner, type) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Type)
+    (@inner $sb:expr, type) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Type)
     };
 
-    (@inner, unsafe) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Unsafe)
+    (@inner $sb:expr, unsafe) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Unsafe)
     };
 
-    (@inner, use) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Use)
+    (@inner $sb:expr, use) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Use)
     };
 
-    (@inner, where) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Where)
+    (@inner $sb:expr, where) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Where)
     };
 
-    (@inner, while) => {
-        $crate::TokenTree::Terminal($crate::Terminal::While)
+    (@inner $sb:expr, while) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::While)
     };
 
     // Keywords that are also reserved
-    (@inner, abstract) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Abstract)
+    (@inner $sb:expr, abstract) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Abstract)
     };
 
-    (@inner, alignof) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Alignof)
+    (@inner $sb:expr, alignof) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Alignof)
     };
 
-    (@inner, become) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Become)
+    (@inner $sb:expr, become) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Become)
     };
 
-    (@inner, box) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Box)
+    (@inner $sb:expr, box) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Box)
     };
 
-    (@inner, do) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Do)
+    (@inner $sb:expr, do) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Do)
     };
 
-    (@inner, final) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Final)
+    (@inner $sb:expr, final) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Final)
     };
 
-    (@inner, macro) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Macro)
+    (@inner $sb:expr, macro) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Macro)
     };
 
-    (@inner, offsetof) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Offsetof)
+    (@inner $sb:expr, offsetof) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Offsetof)
     };
 
-    (@inner, override) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Override)
+    (@inner $sb:expr, override) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Override)
     };
 
-    (@inner, priv) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Priv)
+    (@inner $sb:expr, priv) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Priv)
     };
 
-    (@inner, proc) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Proc)
+    (@inner $sb:expr, proc) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Proc)
     };
 
-    (@inner, pure) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Pure)
+    (@inner $sb:expr, pure) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Pure)
     };
 
-    (@inner, sizeof) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Sizeof)
+    (@inner $sb:expr, sizeof) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Sizeof)
     };
 
-    (@inner, typeof) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Typeof)
+    (@inner $sb:expr, typeof) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Typeof)
     };
 
-    (@inner, unsized) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Unsized)
+    (@inner $sb:expr, unsized) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Unsized)
     };
 
-    (@inner, virtual) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Virtual)
+    (@inner $sb:expr, virtual) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Virtual)
     };
 
-    (@inner, yield) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Yield)
+    (@inner $sb:expr, yield) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Yield)
     };
 
-    (@inner, await) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Await)
+    (@inner $sb:expr, await) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Await)
     };
 
-    (@inner, dyn) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Dyn)
+    (@inner $sb:expr, dyn) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Dyn)
     };
 
-    (@inner, abstract) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Abstract)
+    (@inner $sb:expr, abstract) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Abstract)
     };
 
-    (@inner, catch) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Catch)
+    (@inner $sb:expr, catch) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Catch)
     };
 
-    (@inner, final) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Final)
+    (@inner $sb:expr, final) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Final)
     };
 
-    (@inner, macro) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Macro)
+    (@inner $sb:expr, macro) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Macro)
     };
 
-    (@inner, override) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Override)
+    (@inner $sb:expr, override) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Override)
     };
 
-    (@inner, priv) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Priv)
+    (@inner $sb:expr, priv) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Priv)
     };
 
-    (@inner, try) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Try)
+    (@inner $sb:expr, try) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Try)
     };
 
-    (@inner, union) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Union)
+    (@inner $sb:expr, union) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Union)
     };
 
-    (@inner, #) => {
+    (@inner $sb:expr, #) => {
         $crate::TokenDescription::Pound
     };
 
-    (@inner, $id:ident) => {
-        $crate::TokenTree::Terminal($crate::Terminal::Ident(stringify!($id).to_string()))
+    (@inner $sb:expr, $id:ident) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Ident(stringify!($id).to_string()))
     };
 
-    ( $( $tt:tt )* ) => {
+    (@with_sb $sb:expr, $( $tt:tt )* ) => {{
         vec![
             $(
-                quote!(@inner, $tt)
+                quote!(@inner $sb, $tt)
             ),*
         ]
-    };
+    }};
+
+    ( $( $tt:tt )* ) => {{
+        let mut span_builder = $crate::span::DebugSpanBuilder::new();
+        quote! { @with_sb span_builder, $( $tt )* }
+    }};
 }
 
 macro_rules! impl_spannable {

--- a/expandable-impl/src/macros.rs
+++ b/expandable-impl/src/macros.rs
@@ -307,6 +307,7 @@ macro_rules! quote {
     }};
 
     ( $( $tt:tt )* ) => {{
+        #[allow(unused_variables, unused_mut)]
         let mut span_builder = $crate::span::DebugSpanBuilder::new();
         quote! { @with_sb span_builder, $( $tt )* }
     }};

--- a/expandable-impl/src/macros.rs
+++ b/expandable-impl/src/macros.rs
@@ -254,7 +254,7 @@ macro_rules! quote {
     };
 
     (@inner $sb:expr, await) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Await)
+        quote!(@mk_term $sb, $crate::Terminal::Await)
     };
 
     (@inner $sb:expr, dyn) => {
@@ -294,7 +294,7 @@ macro_rules! quote {
     };
 
     (@inner $sb:expr, #) => {
-        $crate::TokenDescription::Pound
+        quote!(@mk_term $sb, $crate::Terminal::Pound)
     };
 
     (@inner $sb:expr, $id:ident) => {

--- a/expandable-impl/src/macros.rs
+++ b/expandable-impl/src/macros.rs
@@ -7,247 +7,250 @@ macro_rules! quote {
         $crate::TokenTree::parenthesed($sb.mk_span(), quote! { @with_sb $sb, $( $tt )* })
     };
 
-
     (@inner $sb:expr, { $( $tt:tt )* } ) => {
         $crate::TokenTree::curlyBraced($sb.mk_span(), quote! { @with_sb $sb, $( $tt )* })
     };
 
+    (@mk_term $sb:expr, $term:expr) => {
+        $crate::TokenTree::terminal($sb.mk_span(), $term)
+    };
+
     (@inner $sb:expr, @) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Dollar)
+        quote!(@mk_term $sb, $crate::Terminal::Dollar)
     };
 
     (@inner $sb:expr, :) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Colon)
+        quote!(@mk_term $sb, $crate::Terminal::Colon)
     };
 
     (@inner $sb:expr, ?) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::QuestionMark)
+        quote!(@mk_term $sb, $crate::Terminal::QuestionMark)
     };
 
     (@inner $sb:expr, +) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Plus)
+        quote!(@mk_term $sb, $crate::Terminal::Plus)
     };
 
     (@inner $sb:expr, *) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Times)
+        quote!(@mk_term $sb, $crate::Terminal::Times)
     };
 
     (@inner $sb:expr, =>) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::FatArrow)
+        quote!(@mk_term $sb, $crate::Terminal::FatArrow)
     };
 
     (@inner $sb:expr, ;) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Semi)
+        quote!(@mk_term $sb, $crate::Terminal::Semi)
     };
 
     // Keywords
     (@inner $sb:expr, as) => {
-        $crate::TokenTree::terminal($sb.make_span(), $crate::Terminal::As)
+        quote!(@mk_term $sb, $crate::Terminal::As)
     };
 
     (@inner $sb:expr, break) => {
-        $crate::TokenTree::terminal($sb.make_span(), $crate::Terminal::Break)
+        quote!(@mk_term $sb, $crate::Terminal::Break)
     };
 
     (@inner $sb:expr, const) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Const)
+        quote!(@mk_term $sb, $crate::Terminal::Const)
     };
 
     (@inner $sb:expr, continue) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Continue)
+        quote!(@mk_term $sb, $crate::Terminal::Continue)
     };
 
     (@inner $sb:expr, crate) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Crate)
+        quote!(@mk_term $sb, $crate::Terminal::Crate)
     };
 
     (@inner $sb:expr, else) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Else)
+        quote!(@mk_term $sb, $crate::Terminal::Else)
     };
 
     (@inner $sb:expr, enum) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Enum)
+        quote!(@mk_term $sb, $crate::Terminal::Enum)
     };
 
     (@inner $sb:expr, extern) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Extern)
+        quote!(@mk_term $sb, $crate::Terminal::Extern)
     };
 
     (@inner $sb:expr, false) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::False)
+        quote!(@mk_term $sb, $crate::Terminal::False)
     };
 
     (@inner $sb:expr, fn) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Fn)
+        quote!(@mk_term $sb, $crate::Terminal::Fn)
     };
 
     (@inner $sb:expr, for) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::For)
+        quote!(@mk_term $sb, $crate::Terminal::For)
     };
 
     (@inner $sb:expr, if) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::If)
+        quote!(@mk_term $sb, $crate::Terminal::If)
     };
 
     (@inner $sb:expr, impl) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Impl)
+        quote!(@mk_term $sb, $crate::Terminal::Impl)
     };
 
     (@inner $sb:expr, in) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::In)
+        quote!(@mk_term $sb, $crate::Terminal::In)
     };
 
     (@inner $sb:expr, let) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Let)
+        quote!(@mk_term $sb, $crate::Terminal::Let)
     };
 
     (@inner $sb:expr, loop) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Loop)
+        quote!(@mk_term $sb, $crate::Terminal::Loop)
     };
 
     (@inner $sb:expr, match) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Match)
+        quote!(@mk_term $sb, $crate::Terminal::Match)
     };
 
     (@inner $sb:expr, mod) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Mod)
+        quote!(@mk_term $sb, $crate::Terminal::Mod)
     };
 
     (@inner $sb:expr, move) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Move)
+        quote!(@mk_term $sb, $crate::Terminal::Move)
     };
 
     (@inner $sb:expr, mut) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Mut)
+        quote!(@mk_term $sb, $crate::Terminal::Mut)
     };
 
     (@inner $sb:expr, pub) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Pub)
+        quote!(@mk_term $sb, $crate::Terminal::Pub)
     };
 
     (@inner $sb:expr, ref) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Ref)
+        quote!(@mk_term $sb, $crate::Terminal::Ref)
     };
 
     (@inner $sb:expr, return) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Return)
+        quote!(@mk_term $sb, $crate::Terminal::Return)
     };
 
     (@inner $sb:expr, self) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Self_)
+        quote!(@mk_term $sb, $crate::Terminal::Self_)
     };
 
     (@inner $sb:expr, Self) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::SelfUpper)
+        quote!(@mk_term $sb, $crate::Terminal::SelfType)
     };
 
     (@inner $sb:expr, static) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Static)
+        quote!(@mk_term $sb, $crate::Terminal::Static)
     };
 
     (@inner $sb:expr, struct) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Struct)
+        quote!(@mk_term $sb, $crate::Terminal::Struct)
     };
 
     (@inner $sb:expr, super) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Super)
+        quote!(@mk_term $sb, $crate::Terminal::Super)
     };
 
     (@inner $sb:expr, trait) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Trait)
+        quote!(@mk_term $sb, $crate::Terminal::Trait)
     };
 
     (@inner $sb:expr, true) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::True)
+        quote!(@mk_term $sb, $crate::Terminal::True)
     };
 
     (@inner $sb:expr, type) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Type)
+        quote!(@mk_term $sb, $crate::Terminal::Type)
     };
 
     (@inner $sb:expr, unsafe) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Unsafe)
+        quote!(@mk_term $sb, $crate::Terminal::Unsafe)
     };
 
     (@inner $sb:expr, use) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Use)
+        quote!(@mk_term $sb, $crate::Terminal::Use)
     };
 
     (@inner $sb:expr, where) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Where)
+        quote!(@mk_term $sb, $crate::Terminal::Where)
     };
 
     (@inner $sb:expr, while) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::While)
+        quote!(@mk_term $sb, $crate::Terminal::While)
     };
 
     // Keywords that are also reserved
     (@inner $sb:expr, abstract) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Abstract)
+        quote!(@mk_term $sb, $crate::Terminal::Abstract)
     };
 
     (@inner $sb:expr, alignof) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Alignof)
+        quote!(@mk_term $sb, $crate::Terminal::Alignof)
     };
 
     (@inner $sb:expr, become) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Become)
+        quote!(@mk_term $sb, $crate::Terminal::Become)
     };
 
     (@inner $sb:expr, box) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Box)
+        quote!(@mk_term $sb, $crate::Terminal::Box)
     };
 
     (@inner $sb:expr, do) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Do)
+        quote!(@mk_term $sb, $crate::Terminal::Do)
     };
 
     (@inner $sb:expr, final) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Final)
+        quote!(@mk_term $sb, $crate::Terminal::Final)
     };
 
     (@inner $sb:expr, macro) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Macro)
+        quote!(@mk_term $sb, $crate::Terminal::Macro)
     };
 
     (@inner $sb:expr, offsetof) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Offsetof)
+        quote!(@mk_term $sb, $crate::Terminal::Offsetof)
     };
 
     (@inner $sb:expr, override) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Override)
+        quote!(@mk_term $sb, $crate::Terminal::Override)
     };
 
     (@inner $sb:expr, priv) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Priv)
+        quote!(@mk_term $sb, $crate::Terminal::Priv)
     };
 
     (@inner $sb:expr, proc) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Proc)
+        quote!(@mk_term $sb, $crate::Terminal::Proc)
     };
 
     (@inner $sb:expr, pure) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Pure)
+        quote!(@mk_term $sb, $crate::Terminal::Pure)
     };
 
     (@inner $sb:expr, sizeof) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Sizeof)
+        quote!(@mk_term $sb, $crate::Terminal::Sizeof)
     };
 
     (@inner $sb:expr, typeof) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Typeof)
+        quote!(@mk_term $sb, $crate::Terminal::Typeof)
     };
 
     (@inner $sb:expr, unsized) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Unsized)
+        quote!(@mk_term $sb, $crate::Terminal::Unsized)
     };
 
     (@inner $sb:expr, virtual) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Virtual)
+        quote!(@mk_term $sb, $crate::Terminal::Virtual)
     };
 
     (@inner $sb:expr, yield) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Yield)
+        quote!(@mk_term $sb, $crate::Terminal::Yield)
     };
 
     (@inner $sb:expr, await) => {
@@ -255,39 +258,39 @@ macro_rules! quote {
     };
 
     (@inner $sb:expr, dyn) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Dyn)
+        quote!(@mk_term $sb, $crate::Terminal::Dyn)
     };
 
     (@inner $sb:expr, abstract) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Abstract)
+        quote!(@mk_term $sb, $crate::Terminal::Abstract)
     };
 
     (@inner $sb:expr, catch) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Catch)
+        quote!(@mk_term $sb, $crate::Terminal::Catch)
     };
 
     (@inner $sb:expr, final) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Final)
+        quote!(@mk_term $sb, $crate::Terminal::Final)
     };
 
     (@inner $sb:expr, macro) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Macro)
+        quote!(@mk_term $sb, $crate::Terminal::Macro)
     };
 
     (@inner $sb:expr, override) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Override)
+        quote!(@mk_term $sb, $crate::Terminal::Override)
     };
 
     (@inner $sb:expr, priv) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Priv)
+        quote!(@mk_term $sb, $crate::Terminal::Priv)
     };
 
     (@inner $sb:expr, try) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Try)
+        quote!(@mk_term $sb, $crate::Terminal::Try)
     };
 
     (@inner $sb:expr, union) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Union)
+        quote!(@mk_term $sb, $crate::Terminal::Union)
     };
 
     (@inner $sb:expr, #) => {
@@ -295,7 +298,7 @@ macro_rules! quote {
     };
 
     (@inner $sb:expr, $id:ident) => {
-        $crate::TokenTree::terminal($sb.mk_span(), $crate::Terminal::Ident(stringify!($id).to_string()))
+        quote!(@mk_term $sb, $crate::Terminal::Ident(stringify!($id).to_string()))
     };
 
     (@with_sb $sb:expr, $( $tt:tt )* ) => {{

--- a/expandable-impl/src/matcher.rs
+++ b/expandable-impl/src/matcher.rs
@@ -408,12 +408,12 @@ mod local_tree_to_matcher {
                         bindings: {
                             "a": BindingData {
                                 kind: Ident,
-                                span: (),
+                                span: 2,
                                 repetition_stack: [],
                             },
                             "b": BindingData {
                                 kind: Expr,
-                                span: (),
+                                span: 7,
                                 repetition_stack: [],
                             },
                         },
@@ -432,7 +432,7 @@ mod local_tree_to_matcher {
                         bindings: {
                             "a": BindingData {
                                 kind: Ident,
-                                span: (),
+                                span: 5,
                                 repetition_stack: [],
                             },
                         },
@@ -451,7 +451,7 @@ mod local_tree_to_matcher {
                         bindings: {
                             "a": BindingData {
                                 kind: Ident,
-                                span: (),
+                                span: 4,
                                 repetition_stack: [
                                     ZeroOrMore,
                                 ],

--- a/expandable-impl/src/span.rs
+++ b/expandable-impl/src/span.rs
@@ -1,4 +1,3 @@
-use std::cell::Cell;
 use std::fmt::{Debug, Formatter};
 
 #[derive(Copy, Clone)]
@@ -11,19 +10,17 @@ impl Debug for DebugSpan {
 }
 
 pub(crate) struct DebugSpanBuilder {
-    counter: Cell<usize>,
+    counter: usize,
 }
 
 impl DebugSpanBuilder {
     pub(crate) fn new() -> DebugSpanBuilder {
-        DebugSpanBuilder {
-            counter: Cell::new(0),
-        }
+        DebugSpanBuilder { counter: 0 }
     }
 
-    pub(crate) fn mk_span(&self) -> DebugSpan {
-        let id = self.counter.get();
-        self.counter.set(id + 1);
+    pub(crate) fn mk_span(&mut self) -> DebugSpan {
+        let id = self.counter;
+        self.counter += 1;
         DebugSpan(id)
     }
 }

--- a/expandable-impl/src/span.rs
+++ b/expandable-impl/src/span.rs
@@ -1,0 +1,29 @@
+use std::cell::Cell;
+use std::fmt::{Debug, Formatter};
+
+#[derive(Copy, Clone)]
+pub(crate) struct DebugSpan(pub(crate) usize);
+
+impl Debug for DebugSpan {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+pub(crate) struct DebugSpanBuilder {
+    counter: Cell<usize>,
+}
+
+impl DebugSpanBuilder {
+    pub(crate) fn new() -> DebugSpanBuilder {
+        DebugSpanBuilder {
+            counter: Cell::new(0),
+        }
+    }
+
+    pub(crate) fn mk_span(&self) -> DebugSpan {
+        let id = self.counter.get();
+        self.counter.set(id + 1);
+        DebugSpan(id)
+    }
+}

--- a/expandable-impl/src/substitution.rs
+++ b/expandable-impl/src/substitution.rs
@@ -204,7 +204,7 @@ mod tests {
                                     "a",
                                 ),
                             ),
-                            span: (),
+                            span: 0,
                         },
                         TokenTree {
                             kind: Terminal(
@@ -212,7 +212,7 @@ mod tests {
                                     "b",
                                 ),
                             ),
-                            span: (),
+                            span: 1,
                         },
                         TokenTree {
                             kind: Terminal(
@@ -220,7 +220,7 @@ mod tests {
                                     "c",
                                 ),
                             ),
-                            span: (),
+                            span: 2,
                         },
                     ],
                 )
@@ -238,7 +238,7 @@ mod tests {
                             kind: Fragment(
                                 "a",
                             ),
-                            span: (),
+                            span: 1,
                         },
                     ],
                 )
@@ -261,16 +261,16 @@ mod tests {
                                                 "test",
                                             ),
                                         ),
-                                        span: (),
+                                        span: 2,
                                     },
                                 ],
                                 separator: None,
                                 quantifier: RepetitionQuantifier {
                                     kind: ZeroOrMore,
-                                    span: (),
+                                    span: 3,
                                 },
                             },
-                            span: (),
+                            span: 3,
                         },
                     ],
                 )
@@ -291,16 +291,16 @@ mod tests {
                                         kind: Fragment(
                                             "a",
                                         ),
-                                        span: (),
+                                        span: 3,
                                     },
                                 ],
                                 separator: None,
                                 quantifier: RepetitionQuantifier {
                                     kind: ZeroOrOne,
-                                    span: (),
+                                    span: 4,
                                 },
                             },
-                            span: (),
+                            span: 4,
                         },
                     ],
                 )


### PR DESCRIPTION
The test suite previously used `()` as span. This makes debugging a pain, as the only information we have about a token is `()`. This commit fixes this by using a custom debug-only `DebugSpan` instead. This type wraps an `usize` that starts at `0` at each call to `quote` and is monotonically increasing:

```rs
quote! {
    fn /* 0 */ h2g2 /* 1 */ ( /* 2 */ ) /* 2 */ -> /* 3 */ usize /* 4 */ { /* 5 */
        42 /* 6 */
    } /* 5 */
}
```

This commit will make development _massively_ easier.