### PR TITLE
Bring back the repetition stack check

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,25 @@ This is caused by the fact that other macros may add more constrains on the
 macro invocation. _This requirement may be lifted in the future for macros
 that call themselves._
 
+### The repetition stack must match
+
+This crate requires a metavariable indication used in a transcriber to have
+the same repetition stack as the corresponding metavariable that appears in
+the matcher.
+
+For instance, the following code is rejected by `expandable`:
+
+```rust,compile_fail
+#[expandable::expr]
+macro_rules! fns {
+    ($($a:ident)*) => {
+        $(
+            fn $a() {}
+        )+
+    }
+}
+```
+
 ## Minimal Supported Rust Version (MSRV), syntax support and stability
 
 _`expandable` supports Rust 1.65 and above. Bumping the MSRV is

--- a/expandable-impl/src/error.rs
+++ b/expandable-impl/src/error.rs
@@ -70,29 +70,34 @@ pub enum Error<Span> {
         where_: Span,
     },
 
-    /// A variable is being repeated with a repetition stack that does not
-    /// match the matched repetition stack.
+    /// A variable is being repeated with a sequence of operator that does not
+    /// match the one used when the variable was declared.
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```rust,compile_fail
     /// macro_rules! subtraction {
-    ///     ( $( $a:literal )-* ) => {
-    ///         $( $a )-+
+    ///     ( $( $first:literal $( - $then:literal )* )? ) => {
+    ///         $first $( - $then )*
     ///     };
     /// }
     ///
     /// subtraction!(101 - 42);
     /// ```
     ///
-    /// In this example, the repetition nesting of the matched metavariable `a`
-    /// is `*`, while the nesting of the metavariable indication `a` is `+`.
+    /// In this example, the repetition nesting of the matched metavariable `then`
+    /// is `?*`, while the nesting of the metavariable indication `then` is `*`.
+    ///
+    /// This variant represents both the case where the amount of repetitions
+    /// does not match (which is an error) and the case where the repetition
+    /// operators used do not match (which is allowed, but can lead to confusing
+    /// errors).
     InvalidRepetitionNesting {
         /// The name of the metavariable.
         metavariable_name: String,
         /// Where the metavariable was declared.
         decl_span: Span,
-        /// Where the metavariable was used with an incorrecting nesting.
+        /// Where the metavariable was used with an incorrect nesting.
         usage_span: Span,
         /// The nesting used when the metavariable was declared.
         expected_nesting: Vec<RepetitionQuantifierKind>,

--- a/expandable-impl/src/repetition_stack.rs
+++ b/expandable-impl/src/repetition_stack.rs
@@ -129,8 +129,8 @@ mod tests {
     repetition_match_test! {
         #[should_panic = "called `Result::unwrap()` on an `Err` value: InvalidRepetitionNesting { \
             metavariable_name: \"a\", \
-            decl_span: (), \
-            usage_span: (), \
+            decl_span: 5, \
+            usage_span: 4, \
             expected_nesting: [ZeroOrMore], \
             got_nesting: [OneOrMore] \
         }"]
@@ -144,8 +144,8 @@ mod tests {
     repetition_match_test! {
         #[should_panic = "called `Result::unwrap()` on an `Err` value: InvalidRepetitionNesting { \
             metavariable_name: \"a\", \
-            decl_span: (), \
-            usage_span: (), \
+            decl_span: 9, \
+            usage_span: 8, \
             expected_nesting: [OneOrMore, ZeroOrMore, ZeroOrOne], \
             got_nesting: [OneOrMore, ZeroOrOne, ZeroOrMore] \
         }"]

--- a/expandable-impl/src/repetition_stack.rs
+++ b/expandable-impl/src/repetition_stack.rs
@@ -17,8 +17,6 @@ pub(crate) fn check<Span>(
 where
     Span: Copy,
 {
-    // TODO(perf): we could avoid many allocations by storing the stack depth
-    // instead of the stack itself.
     let usages = substitution
         .iter()
         .flat_map(|e| collect_usages(e, &LameLinkedList::Nil));
@@ -32,7 +30,7 @@ where
                 span,
                 ..
             }) => {
-                if stack.len() != repetition_stack.len() {
+                if &stack != repetition_stack {
                     return Err(Error::InvalidRepetitionNesting {
                         metavariable_name: name.to_string(),
                         decl_span: *span,
@@ -129,6 +127,13 @@ mod tests {
     }
 
     repetition_match_test! {
+        #[should_panic = "called `Result::unwrap()` on an `Err` value: InvalidRepetitionNesting { \
+            metavariable_name: \"a\", \
+            decl_span: (), \
+            usage_span: (), \
+            expected_nesting: [ZeroOrMore], \
+            got_nesting: [OneOrMore] \
+        }"]
         fn nonmatching_stack_1() {
             {
                 ( @( @a:ident )* ) => { @( @a )+ }
@@ -137,6 +142,13 @@ mod tests {
     }
 
     repetition_match_test! {
+        #[should_panic = "called `Result::unwrap()` on an `Err` value: InvalidRepetitionNesting { \
+            metavariable_name: \"a\", \
+            decl_span: (), \
+            usage_span: (), \
+            expected_nesting: [OneOrMore, ZeroOrMore, ZeroOrOne], \
+            got_nesting: [OneOrMore, ZeroOrOne, ZeroOrMore] \
+        }"]
         fn nonmatching_stack_2() {
             {
                 ( @( @( @( @a:ident )? )* )+ ) => { @( @( @( @a )* )? )+ }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,25 @@
 //! macro invocation. _This requirement may be lifted in the future for macros
 //! that call themselves._
 //!
+//! ### The repetition stack must match
+//!
+//! This crate requires a metavariable indication used in a transcriber to have
+//! the same repetition stack as the corresponding metavariable that appears in
+//! the matcher.
+//!
+//! For instance, the following code is rejected by `expandable`:
+//!
+//! ```rust,compile_fail
+//! #[expandable::expr]
+//! macro_rules! fns {
+//!     ($($a:ident)*) => {
+//!         $(
+//!             fn $a() {}
+//!         )+
+//!     }
+//! }
+//! ```
+//!
 //! ## Minimal Supported Rust Version (MSRV), syntax support and stability
 //!
 //! _`expandable` supports Rust 1.65 and above. Bumping the MSRV is

--- a/tests/ui/fail/bad_nesting_1.stderr
+++ b/tests/ui/fail/bad_nesting_1.stderr
@@ -1,4 +1,4 @@
-error: the matcher defines one repetition (`?`) for a but the transcriber uses no repetition
+error: the repetition used for `a` (no repetition) is different from how it is matched (`?`).
  --> tests/ui/fail/bad_nesting_1.rs:5:10
   |
 5 |         $a

--- a/tests/ui/fail/bad_nesting_2.stderr
+++ b/tests/ui/fail/bad_nesting_2.stderr
@@ -1,4 +1,4 @@
-error: the matcher defines 3 repetitions (`?+*`) for a but the transcriber uses one repetition (`*`)
+error: the repetition used for `a` (`*`) is different from how it is matched (`?+*`).
  --> tests/ui/fail/bad_nesting_2.rs:5:13
   |
 5 |         $( $a )*


### PR DESCRIPTION
This is basically a fancy revert of #2.

It turns out that using a different delimiter in the macro describer allows to add additional repetition constraints, which further complicates the analyses. This PR makes it illegal to use a different repetition operator and actually documents it.

See [_The invisible macro transcriber constraint_ (blogpost)](https://scrabsha.github.io/invisible-macro-transcriber-constrain/) for more.