### PR TITLE
Add function call parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ macro_rules! js_concat {
 
 This emits the following error [^error-message]:
 ```none
-error: Potentially invalid expansion. Expected an identifier.
+error: Potentially invalid expansion. Expected an identifier, if.
  --> tests/ui/fail/js_concat.rs:4:16
   |
 4 |         $left ++ $right

--- a/expandable-impl/src/grammar.rs
+++ b/expandable-impl/src/grammar.rs
@@ -371,6 +371,9 @@ generate_grammar! {
             "expr" => AfterExpr;
             Ident => AfterExpr;
             If => ExprStart, Condition;
+
+            // <expr> ( <expr>, )
+            RParen, FnArgListThen => AfterExpr;
         },
 
         #[accepting]
@@ -380,6 +383,16 @@ generate_grammar! {
             Times => ExprStart;
             RBrace, FnBlockExpr => ItemStart;
             LBrace, Condition => ExprStart, Consequence;
+
+            // <expr> (
+            LParen => ExprStart, FnArgListFirst;
+            // <expr>, <expr>, ...
+            Comma, FnArgListFirst => ExprStart, FnArgListThen;
+            Comma, FnArgListThen => ExprStart, FnArgListThen;
+            // <expr> )
+            RParen, FnArgListFirst => AfterExpr;
+            RParen, FnArgListThen => AfterExpr;
+
             // We don't continue to `AfterExpr` because we want to parse an
             // optional `else` branch.
             RBrace, Consequence => AfterIf;
@@ -394,6 +407,16 @@ generate_grammar! {
             Times => ExprStart;
             RBrace, FnBlockExpr => ItemStart;
             LBrace, Condition => ExprStart, Consequence;
+
+            // <expr> (
+            LParen => ExprStart, FnArgListFirst;
+            // <expr>, <expr>, ...
+            Comma, FnArgListFirst => ExprStart, FnArgListThen;
+            Comma, FnArgListThen => ExprStart, FnArgListThen;
+            // <expr> )
+            RParen, FnArgListFirst => AfterExpr;
+            RParen, FnArgListThen => AfterExpr;
+
             // We don't continue to `AfterIf` because we want to parse an
             // optional `else` branch.
             RBrace, Consequence => AfterIf;
@@ -459,4 +482,6 @@ pub(crate) enum StackSymbol {
     Condition,
     Consequence,
     Alternative,
+    FnArgListFirst,
+    FnArgListThen,
 }

--- a/expandable-impl/src/grammar.rs
+++ b/expandable-impl/src/grammar.rs
@@ -372,6 +372,8 @@ generate_grammar! {
             Ident => AfterExpr;
             If => ExprStart, Condition;
 
+            // <expr> ()
+            RParen, FnArgListFirst => AfterExpr;
             // <expr> ( <expr>, )
             RParen, FnArgListThen => AfterExpr;
         },

--- a/expandable-impl/src/lib.rs
+++ b/expandable-impl/src/lib.rs
@@ -611,4 +611,76 @@ mod tests {
             }
         }
     }
+
+    check_macro_test! {
+        fn_call_1 {
+            #[expr]
+            {
+                () => { a(b) };
+            }
+        }
+    }
+
+    check_macro_test! {
+        fn_call_2 {
+            #[expr]
+            {
+                () => { a(b, c) };
+            }
+        }
+    }
+
+    check_macro_test! {
+        fn_call_3 {
+            #[expr]
+            {
+                () => { a(b, c, d) };
+            }
+        }
+    }
+
+    check_macro_test! {
+        fn_call_4 {
+            #[expr]
+            {
+                () => {
+                    a(
+                        b,
+                        c,
+                        d,
+                    )
+                };
+            }
+        }
+    }
+
+    check_macro_test! {
+        fn_call_5 {
+            #[expr]
+            {
+                () => {
+                    a(
+                        b + c,
+                        if d { e },
+                        if f { g } else { h }
+                    )
+                };
+            }
+        }
+    }
+
+    check_macro_test! {
+        fn_call_6 {
+            #[expr]
+            {
+                () => {
+                    a(
+                        b + c,
+                        if d { e },
+                        if f { g } else { h },
+                    )
+                };
+            }
+        }
+    }
 }

--- a/expandable-impl/src/macros.rs
+++ b/expandable-impl/src/macros.rs
@@ -43,6 +43,10 @@ macro_rules! quote {
         quote!(@mk_term $sb, $crate::Terminal::Semi)
     };
 
+    (@inner $sb:expr, ,) => {
+        quote!(@mk_term $sb, $crate::Terminal::Comma)
+    };
+
     // Keywords
     (@inner $sb:expr, as) => {
         quote!(@mk_term $sb, $crate::Terminal::As)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //!
 //! This emits the following error [^error-message]:
 //! ```none
-//! error: Potentially invalid expansion. Expected an identifier.
+//! error: Potentially invalid expansion. Expected an identifier, if.
 //!  --> tests/ui/fail/js_concat.rs:4:16
 //!   |
 //! 4 |         $left ++ $right

--- a/tests/ui/fail/invalid_fn_calls.rs
+++ b/tests/ui/fail/invalid_fn_calls.rs
@@ -1,0 +1,26 @@
+#[allow(unused_macros)]
+#[expandable::expr]
+macro_rules! call {
+    // No argument, just a comma
+    ($fn_name:ident()) => {
+        $fn_name(,)
+    };
+}
+
+#[allow(unused_macros)]
+#[expandable::expr]
+macro_rules! call_ {
+    ($fn_name:ident()) => {
+        $fn_name(,,)
+    };
+}
+
+#[allow(unused_macros)]
+#[expandable::expr]
+macro_rules! call2 {
+    ($fn_name:ident($arg1:expr, $arg2:expr)) => {
+        $fn_name($arg1 $arg2)
+    };
+}
+
+fn main() {}

--- a/tests/ui/fail/invalid_fn_calls.stderr
+++ b/tests/ui/fail/invalid_fn_calls.stderr
@@ -1,0 +1,17 @@
+error: Potentially invalid expansion. Expected an identifier, if, a `)`.
+ --> tests/ui/fail/invalid_fn_calls.rs:6:18
+  |
+6 |         $fn_name(,)
+  |                  ^
+
+error: Potentially invalid expansion. Expected an identifier, if, a `)`.
+  --> tests/ui/fail/invalid_fn_calls.rs:14:18
+   |
+14 |         $fn_name(,,)
+   |                  ^
+
+error: Potentially invalid expansion. Expected `+`, `*`, a `(`, `,`, a `)`.
+  --> tests/ui/fail/invalid_fn_calls.rs:22:25
+   |
+22 |         $fn_name($arg1 $arg2)
+   |                         ^^^^

--- a/tests/ui/pass/fn_calls.rs
+++ b/tests/ui/pass/fn_calls.rs
@@ -1,0 +1,17 @@
+#[allow(unused_macros)]
+#[expandable::expr]
+macro_rules! call {
+    ($fn_name:ident()) => {
+        $fn_name()
+    };
+
+    ($fn_name:ident($($args:expr),+)) => {
+        $fn_name($($args),+)
+    };
+
+    ($fn_name:ident($($args:expr,)+)) => {
+        $fn_name($($args,)+)
+    };
+}
+
+fn main() {}


### PR DESCRIPTION
This commit adds support for function call parsing. That is, anything that looks like:

$$\texttt{expr} \texttt{(} \texttt{expr} \\; \left( \texttt{,} \texttt{expr} \right)^{*} \\;  \texttt{)}$$

The next steps will be:
- Binary operators (we already have `*` and `+`, we want all of them!),
- Path expressions.