### PR TITLE
Fix an embarassing bug in the "stack size reduction" optimization

### DIFF
--- a/expandable-impl/src/expansion.rs
+++ b/expandable-impl/src/expansion.rs
@@ -150,7 +150,7 @@ where
             .map_err(|expected| Error::InvalidProducedAst { span, expected })?;
 
         let inner_state = after_open_delimiter.fresh_stack();
-        let states = self.parse_stream(DynamicStateSet::singleton(inner_state.clone()), inner)?;
+        let states = self.parse_stream(DynamicStateSet::singleton(inner_state), inner)?;
 
         // Parse close delimiter
         let states = states

--- a/expandable-impl/src/expansion.rs
+++ b/expandable-impl/src/expansion.rs
@@ -144,13 +144,13 @@ where
         initial_state: DynamicState,
     ) -> Result<DynamicStateSet, Error<Span>> {
         // Parse open delimiter
-        let state = initial_state
+        let mut after_open_delimiter = initial_state
             .clone()
             .accept(open)
             .map_err(|expected| Error::InvalidProducedAst { span, expected })?;
 
-        let inner_state = state.fresh_stack();
-        let states = self.parse_stream(DynamicStateSet::singleton(inner_state), inner)?;
+        let inner_state = after_open_delimiter.fresh_stack();
+        let states = self.parse_stream(DynamicStateSet::singleton(inner_state.clone()), inner)?;
 
         // Parse close delimiter
         let states = states
@@ -158,7 +158,7 @@ where
             .map(|state| {
                 state
                     .accept(close)
-                    .map(|state| state.with_old_stack(&initial_state))
+                    .map(|state| state.with_old_stack(&after_open_delimiter))
                     .map_err(|expected| Error::InvalidProducedAst { span, expected })
             })
             .collect::<Result<DynamicStateSet, _>>()?;

--- a/expandable-impl/src/grammar.rs
+++ b/expandable-impl/src/grammar.rs
@@ -30,23 +30,17 @@ impl DynamicState {
         self.stack.is_empty() && self.state.is_accepting()
     }
 
-    pub(crate) fn fresh_stack(&self) -> DynamicState {
-        let symbol = self.stack.last().unwrap();
+    pub(crate) fn fresh_stack(&mut self) -> DynamicState {
+        let symbol = self.stack.pop().unwrap();
         DynamicState {
             state: self.state,
-            stack: smallvec![*symbol],
+            stack: smallvec![symbol],
         }
     }
 
     pub(crate) fn with_old_stack(&self, old_state: &DynamicState) -> DynamicState {
-        let len = old_state.stack.len().saturating_sub(1);
-        let stack = old_state
-            .stack
-            .iter()
-            .copied()
-            .take(len)
-            .chain(self.stack_top())
-            .collect::<SmallVec<[_; 16]>>();
+        assert!(self.stack.is_empty());
+        let stack = old_state.stack.clone();
 
         DynamicState {
             state: self.state,
@@ -219,7 +213,7 @@ macro_rules! generate_grammar {
                             push: *out_sym,
                         })
                     } else { None }
-                }).ok_or_else(|| self.follow())
+                }).ok_or_else(|| self.follow(top))
             }
 
             fn follow(self) -> Vec<TokenDescription> {

--- a/expandable-impl/src/grammar.rs
+++ b/expandable-impl/src/grammar.rs
@@ -216,12 +216,14 @@ macro_rules! generate_grammar {
                 }).ok_or_else(|| self.follow(top))
             }
 
-            fn follow(self) -> Vec<TokenDescription> {
-               Self::TRANSITIONS[self as usize].iter().filter_map(|(descr, _, _, _)| {
-                    if matches!(descr, TokenDescription::Fragment(_)) {
-                        None
-                    } else {
+            fn follow(self, top: Option<StackSymbol>) -> Vec<TokenDescription> {
+                Self::TRANSITIONS[self as usize].iter().filter_map(|(descr, in_sym, _, _)| {
+                    // We try to be smårt here and only suggest tokens that we
+                    // can actually accept.
+                    if !matches!(descr, TokenDescription::Fragment(_)) && (in_sym.is_none() || in_sym == &top) {
                         Some(*descr)
+                    } else {
+                        None
                     }
                 }).collect()
             }

--- a/expandable-impl/src/span.rs
+++ b/expandable-impl/src/span.rs
@@ -1,3 +1,7 @@
+// Architectural invariant: this module contains a development-only span type
+// aiming to ease debugging. This module is cfg-ed out when the crate is used
+// as a dependency.
+
 use std::fmt::{Debug, Formatter};
 
 #[derive(Copy, Clone)]


### PR DESCRIPTION
TLDR: there were two different states in the scope and I picked the wrong one :(

The optimization itself has been reworked in order to make it more natural: the `fresh_stack` method pops a label from the old stack, and creates a new state containing just this label. Conversely, the remaining label is reintroduced in the old stack in the `with_old_stack` method.