### PR TITLE
Don't lower `=` to `EqualEqual` in the frontend

### DIFF
--- a/expandable-impl/src/lib.rs
+++ b/expandable-impl/src/lib.rs
@@ -219,7 +219,7 @@ pub(crate) trait Spannable<Span> {
 /// This type allows the end-user to represent the tokens that is passed in the
 /// macro invocation. It is not _exactly_ the same as [`proc_macro::TokenTree`],
 /// as the tokens are grouped differently [^1]. Writing a
-/// [`proc_macro::TokenTree`] -> [`TokenTree`] should not be too hard, but is
+/// "[`proc_macro::TokenTree`] to [`TokenTree`]" should not be too hard, but is
 /// not the scope of this crate.
 ///
 /// [^1]: For instance, `+=` is represented as a single token in declarative

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -501,7 +501,7 @@ fn parse_macro_stream(stream: TokenStream) -> Vec<expandable_impl::TokenTree<Spa
                         Terminal::EqualEqual
                     }
 
-                    s if s.starts_with('=') => Terminal::EqualEqual,
+                    s if s.starts_with('=') => Terminal::Equal,
                     s if s.starts_with(':') => Terminal::Colon,
                     s if s.starts_with(',') => Terminal::Comma,
                     s if s.starts_with('$') => Terminal::Dollar,


### PR DESCRIPTION
I should not write code this late in the night.

The saddest part is that I can't even write a test for this, as the assignment is not handled in the grammar at the moment.

Thanks to @zdimension for noticing this :blush: