### PR TITLE
feat: add arithmetic, bit and comparison expression parsing

### DIFF
--- a/expandable-impl/src/grammar.rs
+++ b/expandable-impl/src/grammar.rs
@@ -250,6 +250,28 @@ token_description! {
         Terminal::Minus => Minus,
         /// A times (`*`).
         Terminal::Times => Times,
+        /// A slash (`/`).
+        Terminal::Slash => Slash,
+        /// A percent sign (`%`).
+        Terminal::Percent => Percent,
+        /// An ampersand (`&`).
+        Terminal::Ampersand => Ampersand,
+        /// A pipe (`|`).
+        Terminal::Pipe => Pipe,
+        /// A caret (`^`).
+        Terminal::Caret => Caret,
+        /// A double left chevron (`<<`).
+        Terminal::DoubleLeftChevron => DoubleLeftChevron,
+        /// A double right chevron (`>>`).
+        Terminal::DoubleRightChevron => DoubleRightChevron,
+        /// A left chevron (`<`).
+        Terminal::LeftChevron => LeftChevron,
+        /// A right chevron (`>`).
+        Terminal::RightChevron => RightChevron,
+        /// A left chevron followed by an equal sign (`<=`).
+        Terminal::LessEqual => LessEqual,
+        /// A right chevron followed by an equal sign (`>=`).
+        Terminal::GreaterEqual => GreaterEqual,
         /// A colon (`:`).
         Terminal::Colon => Colon,
         /// A comma (`,`).
@@ -270,6 +292,8 @@ token_description! {
         Terminal::Equal => Equal,
         /// The equal-equal sign (`==`).
         Terminal::EqualEqual => EqualEqual,
+        /// A bang sign followed by an equal sign (`!=`).
+        Terminal::BangEqual => BangEqual,
         /// A literal
         Terminal::Literal(_) => Literal,
 

--- a/expandable-impl/src/grammar.rs
+++ b/expandable-impl/src/grammar.rs
@@ -414,10 +414,31 @@ generate_grammar! {
         #[accepting]
         // Transitions added here must be added in `AfterIf` as well.
         AfterExpr {
+            // Arithmetic expressions
+            // https://spec.ferrocene.dev/expressions.html#arithmetic-expressions
             Plus => ExprStart;
             Minus => ExprStart;
             Times => ExprStart;
+            Slash => ExprStart;
+            Percent => ExprStart;
+
+            // Bit expressions
+            // https://spec.ferrocene.dev/expressions.html#bit-expressions
+            Ampersand => ExprStart;
+            Pipe => ExprStart;
+            Caret => ExprStart;
+            DoubleLeftChevron => ExprStart;
+            DoubleRightChevron => ExprStart;
+
+            // Comparison expressions
+            // https://spec.ferrocene.dev/expressions.html#comparison-expressions
             EqualEqual => ExprStart;
+            LeftChevron => ExprStart;
+            GreaterEqual => ExprStart;
+            RightChevron => ExprStart;
+            LessEqual => ExprStart;
+            BangEqual => ExprStart;
+
             RBrace, FnBlockExpr => ItemStart;
             LBrace, Condition => ExprStart, Consequence;
 

--- a/expandable-impl/src/lib.rs
+++ b/expandable-impl/src/lib.rs
@@ -320,6 +320,30 @@ pub enum Terminal {
     Equal,
     /// An equal-equal (`==`).
     EqualEqual,
+    /// A percent (`%`).
+    Percent,
+    /// A slash (`/`).
+    Slash,
+    /// A caret (`^`).
+    Caret,
+    /// A pipe (`|`).
+    Pipe,
+    /// An ampersand (`&`).
+    Ampersand,
+    /// A double left chevron (`<<`).
+    DoubleLeftChevron,
+    /// A double right chevron (`>>`).
+    DoubleRightChevron,
+    /// A left chevron (`<`).
+    LeftChevron,
+    /// A right chevron (`>`).
+    RightChevron,
+    /// A bang followed by an equal (`!=`).
+    BangEqual,
+    /// A left chevron followed by an equal (`<=`).
+    LessEqual,
+    /// A right chevron followed by an equal (`>=`).
+    GreaterEqual,
 
     // Currently used keywords
     /// The `as` keyword.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -415,9 +415,26 @@ fn describe(descr: &TokenDescription) -> String {
         TokenDescription::RBrace => "a `}`",
         TokenDescription::Invalid => unreachable!(),
         TokenDescription::Ident => "an identifier",
+
         TokenDescription::Plus => "`+`",
         TokenDescription::Minus => "`-`",
         TokenDescription::Times => "`*`",
+        TokenDescription::Slash => "`/`",
+        TokenDescription::Percent => "`%`",
+
+        TokenDescription::Ampersand => "`&`",
+        TokenDescription::Pipe => "`|`",
+        TokenDescription::Caret => "`^`",
+        TokenDescription::DoubleLeftChevron => "`<<`",
+        TokenDescription::DoubleRightChevron => "`>>`",
+
+        TokenDescription::EqualEqual => "`==`",
+        TokenDescription::LeftChevron => "`<`",
+        TokenDescription::GreaterEqual => "`>=`",
+        TokenDescription::RightChevron => "`>`",
+        TokenDescription::LessEqual => "`<=`",
+        TokenDescription::BangEqual => "`!=`",
+
         TokenDescription::Comma => "`,`",
         TokenDescription::Colon => "`:`",
         TokenDescription::Semi => "`;`",
@@ -426,7 +443,6 @@ fn describe(descr: &TokenDescription) -> String {
         TokenDescription::QuestionMark => "`?`",
         TokenDescription::Dollar => "`$`",
         TokenDescription::Equal => "`=`",
-        TokenDescription::EqualEqual => "`==`",
         TokenDescription::Literal => "a literal",
 
         other => {
@@ -501,7 +517,51 @@ fn parse_macro_stream(stream: TokenStream) -> Vec<expandable_impl::TokenTree<Spa
                         Terminal::EqualEqual
                     }
 
+                    s if s.starts_with("!=") => {
+                        let (last, tail_) = tail.split_first().unwrap();
+                        span = span.join(last.span()).unwrap_or_else(|| p.span());
+                        tail = tail_;
+                        Terminal::BangEqual
+                    }
+
+                    s if s.starts_with("<=") => {
+                        let (last, tail_) = tail.split_first().unwrap();
+                        span = span.join(last.span()).unwrap_or_else(|| p.span());
+                        tail = tail_;
+                        Terminal::LessEqual
+                    }
+
+                    s if s.starts_with(">=") => {
+                        let (last, tail_) = tail.split_first().unwrap();
+                        span = span.join(last.span()).unwrap_or_else(|| p.span());
+                        tail = tail_;
+                        Terminal::GreaterEqual
+                    }
+
+                    s if s.starts_with("<<") => {
+                        let (last, tail_) = tail.split_first().unwrap();
+                        span = span.join(last.span()).unwrap_or_else(|| p.span());
+                        tail = tail_;
+                        Terminal::DoubleLeftChevron
+                    }
+
+                    s if s.starts_with(">>") => {
+                        let (last, tail_) = tail.split_first().unwrap();
+                        span = span.join(last.span()).unwrap_or_else(|| p.span());
+                        tail = tail_;
+                        Terminal::DoubleRightChevron
+                    }
+
+                    s if s.starts_with('%') => Terminal::Percent,
+                    s if s.starts_with('/') => Terminal::Slash,
+                    s if s.starts_with('&') => Terminal::Ampersand,
+                    s if s.starts_with('|') => Terminal::Pipe,
+                    s if s.starts_with('^') => Terminal::Caret,
+
                     s if s.starts_with('=') => Terminal::Equal,
+                    s if s.starts_with('<') => Terminal::LeftChevron,
+                    s if s.starts_with('>') => Terminal::RightChevron,
+
                     s if s.starts_with(':') => Terminal::Colon,
                     s if s.starts_with(',') => Terminal::Comma,
                     s if s.starts_with('$') => Terminal::Dollar,

--- a/tests/ui/fail/invalid_fn_calls.stderr
+++ b/tests/ui/fail/invalid_fn_calls.stderr
@@ -10,7 +10,7 @@ error: Potentially invalid expansion. Expected an identifier, a literal, `if`, a
 14 |         $fn_name(,,)
    |                  ^
 
-error: Potentially invalid expansion. Expected `+`, `-`, `*`, `==`, a `(`, `,`, a `)`.
+error: Potentially invalid expansion. Expected `+`, `-`, `*`, `/`, `%`, `&`, `|`, `^`, `<<`, `>>`, `==`, `<`, `>=`, `>`, `<=`, `!=`, a `(`, `,`, a `)`.
   --> tests/ui/fail/invalid_fn_calls.rs:22:25
    |
 22 |         $fn_name($arg1 $arg2)

--- a/tests/ui/pass/simple_maths.rs
+++ b/tests/ui/pass/simple_maths.rs
@@ -10,6 +10,17 @@ macro_rules! mac {
     () => {
         a + b * c
     };
+    ($( $d:expr, )* ) => {
+        a - b % c $( + $d )*
+    };
+    // Bit expressions
+    () => {
+        a & b | c ^ d << e >> f
+    };
+    // Comparison expressions
+    () => {
+        a == b != c < d > e <= f >= g
+    };
 }
 
 fn main() {}


### PR DESCRIPTION
Two things to note:
- We should establish a naming convention for the `Terminal`s and the `TokenDescription`s. This is a huge mess.
- On the frontend side, we will need to limit the number of `TokenDescription` printed in the error messages.

Relevant links:
- [Arithmetic expressions](https://spec.ferrocene.dev/expressions.html#arithmetic-expressions),
- [Bit expressions](https://spec.ferrocene.dev/expressions.html#bit-expressions),
- [Comparison expressions](https://spec.ferrocene.dev/expressions.html#comparison-expressions).