### PR TITLE
refactor: compute the token descriptions before checking the expansion

### DIFF
--- a/expandable-impl/src/expansion.rs
+++ b/expandable-impl/src/expansion.rs
@@ -92,8 +92,8 @@ where
         tree: &TokenTree<Span>,
     ) -> Result<DynamicStateSet, Error<Span>> {
         match &tree.kind {
-            TokenTreeKind::Terminal(t, _) => state
-                .accept(t)
+            TokenTreeKind::Terminal(_, descr) => state
+                .accept(*descr)
                 .map_err(|expected| Error::InvalidProducedAst {
                     span: tree.span,
                     expected,

--- a/expandable-impl/src/expansion.rs
+++ b/expandable-impl/src/expansion.rs
@@ -92,7 +92,7 @@ where
         tree: &TokenTree<Span>,
     ) -> Result<DynamicStateSet, Error<Span>> {
         match &tree.kind {
-            TokenTreeKind::Terminal(t) => state
+            TokenTreeKind::Terminal(t, _) => state
                 .accept(t)
                 .map_err(|expected| Error::InvalidProducedAst {
                     span: tree.span,

--- a/expandable-impl/src/grammar.rs
+++ b/expandable-impl/src/grammar.rs
@@ -19,11 +19,13 @@ impl DynamicState {
         self.trans(TokenDescription::Fragment(fragment))
     }
 
-    pub(crate) fn accept<Descr>(self, descr: Descr) -> Result<DynamicState, Vec<TokenDescription>>
-    where
-        Descr: Into<TokenDescription>,
-    {
-        self.trans(descr.into())
+    pub(crate) fn accept(
+        self,
+        descr: TokenDescription,
+    ) -> Result<DynamicState, Vec<TokenDescription>> {
+        self.state
+            .trans(descr, self.stack_top())
+            .map(|transition| self.with(transition))
     }
 
     pub(crate) fn is_accepting(&self) -> bool {

--- a/expandable-impl/src/grammar.rs
+++ b/expandable-impl/src/grammar.rs
@@ -16,7 +16,7 @@ impl DynamicState {
         self,
         fragment: FragmentKind,
     ) -> Result<DynamicState, Vec<TokenDescription>> {
-        self.trans(TokenDescription::Fragment(fragment))
+        self.accept(TokenDescription::Fragment(fragment))
     }
 
     pub(crate) fn accept(
@@ -48,12 +48,6 @@ impl DynamicState {
             state: self.state,
             stack,
         }
-    }
-
-    fn trans(self, descr: TokenDescription) -> Result<DynamicState, Vec<TokenDescription>> {
-        self.state
-            .trans(descr, self.stack_top())
-            .map(|transition| self.with(transition))
     }
 
     fn stack_top(&self) -> Option<StackSymbol> {

--- a/expandable-impl/src/repetition_stack.rs
+++ b/expandable-impl/src/repetition_stack.rs
@@ -61,7 +61,7 @@ where
     Span: Copy,
 {
     match &elem.kind {
-        TokenTreeKind::Terminal(_) => Vec::new(),
+        TokenTreeKind::Terminal(_, _) => Vec::new(),
         TokenTreeKind::Parenthesed(inner) | TokenTreeKind::CurlyBraced(inner) => inner
             .iter()
             .flat_map(|elem| collect_usages(elem, stack))

--- a/expandable-impl/src/substitution.rs
+++ b/expandable-impl/src/substitution.rs
@@ -205,6 +205,7 @@ mod tests {
                                 Ident(
                                     "a",
                                 ),
+                                Ident,
                             ),
                             span: 0,
                         },
@@ -213,6 +214,7 @@ mod tests {
                                 Ident(
                                     "b",
                                 ),
+                                Ident,
                             ),
                             span: 1,
                         },
@@ -221,6 +223,7 @@ mod tests {
                                 Ident(
                                     "c",
                                 ),
+                                Ident,
                             ),
                             span: 2,
                         },
@@ -262,6 +265,7 @@ mod tests {
                                             Ident(
                                                 "test",
                                             ),
+                                            Ident,
                                         ),
                                         span: 2,
                                     },

--- a/expandable-impl/src/substitution.rs
+++ b/expandable-impl/src/substitution.rs
@@ -3,19 +3,19 @@
 
 use crate::{
     error::{Error, MacroRuleNode},
-    RepetitionQuantifier, RepetitionQuantifierKind, Spannable, Terminal,
+    RepetitionQuantifier, RepetitionQuantifierKind, Spannable, Terminal, TokenDescription,
     TokenTree as GenericTokenTree, TokenTreeKind as GenericTokenTreeKind,
 };
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) struct TokenTree<Span> {
     pub(crate) kind: TokenTreeKind<Span>,
     pub(crate) span: Span,
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) enum TokenTreeKind<Span> {
-    Terminal(Terminal),
+    Terminal(Terminal, TokenDescription),
     Parenthesed(Vec<TokenTree<Span>>),
     CurlyBraced(Vec<TokenTree<Span>>),
     Fragment(String),
@@ -67,7 +67,8 @@ where
                 }
 
                 GenericTokenTreeKind::Terminal(t) => {
-                    TokenTreeKind::Terminal(t).with_span(token.span)
+                    let descr = TokenDescription::from(&t);
+                    TokenTreeKind::Terminal(t, descr).with_span(token.span)
                 }
 
                 GenericTokenTreeKind::Parenthesed(inner) => {
@@ -117,8 +118,9 @@ where
             }
 
             GenericTokenTreeKind::Terminal(t) => {
+                let descr = TokenDescription::from(&t);
                 let t = TokenTree {
-                    kind: TokenTreeKind::Terminal(t),
+                    kind: TokenTreeKind::Terminal(t, descr),
                     span: token.span,
                 };
 


### PR DESCRIPTION
This allows the transition function to be "more branchless", which will severely reduce the pressure on the "`Token` -> `TokenDescription`" conversion function when checking a repetition.