### PR TITLE
fix: Add the missing AfterIf transitions

### DIFF
--- a/expandable-impl/src/grammar.rs
+++ b/expandable-impl/src/grammar.rs
@@ -501,10 +501,31 @@ generate_grammar! {
         // Must be a superset of `AfterExpr`.
         AfterIf {
             Else => AfterElse;
+            // Arithmetic expressions
+            // https://spec.ferrocene.dev/expressions.html#arithmetic-expressions
             Plus => ExprStart;
-            Star => ExprStart;
             Minus => ExprStart;
+            Star => ExprStart;
+            Slash => ExprStart;
+            Percent => ExprStart;
+
+            // Bit expressions
+            // https://spec.ferrocene.dev/expressions.html#bit-expressions
+            And => ExprStart;
+            Or => ExprStart;
+            Caret => ExprStart;
+            Shl => ExprStart;
+            Shr => ExprStart;
+
+            // Comparison expressions
+            // https://spec.ferrocene.dev/expressions.html#comparison-expressions
             EqualsEquals => ExprStart;
+            GreaterThan => ExprStart;
+            GreaterThanEquals => ExprStart;
+            LessThan => ExprStart;
+            LessThanEquals => ExprStart;
+            NotEquals => ExprStart;
+
             RBrace, FnBlockExpr => ItemStart;
             LBrace, Condition => ExprStart, Consequence;
 
@@ -517,8 +538,17 @@ generate_grammar! {
             RParen, FnArgListFirst => AfterExpr;
             RParen, FnArgListThen => AfterExpr;
 
+            // We don't continue to `AfterExpr` because we want to parse an
+            // optional `else` branch.
+            RBrace, Consequence => AfterIf;
+            RBrace, Alternative => AfterExpr;
+
             // We don't continue to `AfterIf` because we want to parse an
             // optional `else` branch.
+            // This corresponds to the following:
+            //
+            // if <expr> { if <expr> { <expr> } } ...
+            //                                  ^
             RBrace, Consequence => AfterIf;
         },
 

--- a/expandable-impl/src/grammar.rs
+++ b/expandable-impl/src/grammar.rs
@@ -589,3 +589,24 @@ pub(crate) enum StackSymbol {
     FnParam,
     AfterFnParams,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transitions_after_if_is_a_superset_of_after_expr() {
+        State::TRANSITIONS[State::AfterExpr as usize]
+            .iter()
+            .for_each(|(descr, in_sym, _, _)| {
+                assert!(
+                    State::TRANSITIONS[State::AfterIf as usize]
+                        .iter()
+                        .any(|(descr_, in_sym_, _, _)| descr == descr_ && in_sym == in_sym_),
+                    "missing transition for {:?} {:?}. Please add it to `AfterIf` transition set.",
+                    descr,
+                    in_sym
+                );
+            });
+    }
+}


### PR DESCRIPTION
(This is just another instance of me not being able to update multiple things at the same time)

#14 added a bunch of transitions that occurred in the `AfterExpr` state. I forgot to add them in the `AfterIf` state as well. This PR fixes that.

Additionally I added a test so that the CI will break if I ever forget to update the `AfterIf` state. Great!