### PR TITLE
feat: add support for array expressions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -105,7 +105,7 @@ jobs:
         run: cargo +nightly fmt --all -- --check
 
       - name: Check ui tests formatting
-        run: find tests/ -name "*.rs" -exec rustfmt --check {} +
+        run: find tests/ -name "*.rs" -exec rustfmt +nightly --check {} +
 
   readme-check:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ macro_rules! js_concat {
 
 This emits the following error [^error-message]:
 ```none
-error: Potentially invalid expansion. Expected an identifier, a literal, `if`.
+error: Potentially invalid expansion. Expected an identifier, a literal, `if`, a `[`.
  --> tests/ui/fail/js_concat.rs:5:16
   |
 5 |         $left ++ $right

--- a/expandable-impl/src/expansion.rs
+++ b/expandable-impl/src/expansion.rs
@@ -116,6 +116,14 @@ where
                 state,
             ),
 
+            TokenTreeKind::Bracketed(inner) => self.check_delimited_stream(
+                TokenDescription::LBracket,
+                inner,
+                TokenDescription::RBracket,
+                tree.span,
+                state,
+            ),
+
             TokenTreeKind::Fragment(f) => {
                 // This is safe because we ensured at the previous step that
                 // a fragment with that name indeed exists.

--- a/expandable-impl/src/grammar.rs
+++ b/expandable-impl/src/grammar.rs
@@ -445,10 +445,18 @@ generate_grammar! {
             Literal => AfterExpr;
             If => ExprStart, Condition;
 
+            // Array expression
+            // https://spec.ferrocene.dev/expressions.html#array-expressions
+            LBracket => ExprStart, ArrayExprFirst;
+
             // <expr> ()
             RParen, FnArgListFirst => AfterExpr;
             // <expr> ( <expr>, )
             RParen, FnArgListThen => AfterExpr;
+            // []
+            RBracket, ArrayExprFirst => AfterExpr;
+            // [ <expr>, ]
+            RBracket, ArrayExprThen => AfterExpr;
         },
 
         #[accepting]
@@ -479,6 +487,10 @@ generate_grammar! {
             LessThanEquals => ExprStart;
             NotEquals => ExprStart;
 
+            // [ <expr> ]
+            RBracket, ArrayExprFirst => AfterExpr;
+            RBracket, ArrayExprThen => AfterExpr;
+
             RBrace, FnBlockExpr => ItemStart;
             LBrace, Condition => ExprStart, Consequence;
 
@@ -487,6 +499,8 @@ generate_grammar! {
             // <expr>, <expr>, ...
             Comma, FnArgListFirst => ExprStart, FnArgListThen;
             Comma, FnArgListThen => ExprStart, FnArgListThen;
+            Comma, ArrayExprFirst => ExprStart, ArrayExprThen;
+            Comma, ArrayExprThen => ExprStart, ArrayExprThen;
             // <expr> )
             RParen, FnArgListFirst => AfterExpr;
             RParen, FnArgListThen => AfterExpr;
@@ -526,6 +540,10 @@ generate_grammar! {
             LessThanEquals => ExprStart;
             NotEquals => ExprStart;
 
+            // [ <expr> ]
+            RBracket, ArrayExprFirst => AfterExpr;
+            RBracket, ArrayExprThen => AfterExpr;
+
             RBrace, FnBlockExpr => ItemStart;
             LBrace, Condition => ExprStart, Consequence;
 
@@ -534,6 +552,8 @@ generate_grammar! {
             // <expr>, <expr>, ...
             Comma, FnArgListFirst => ExprStart, FnArgListThen;
             Comma, FnArgListThen => ExprStart, FnArgListThen;
+            Comma, ArrayExprFirst => ExprStart, ArrayExprThen;
+            Comma, ArrayExprThen => ExprStart, ArrayExprThen;
             // <expr> )
             RParen, FnArgListFirst => AfterExpr;
             RParen, FnArgListThen => AfterExpr;
@@ -618,6 +638,8 @@ pub(crate) enum StackSymbol {
     FnArgListThen,
     FnParam,
     AfterFnParams,
+    ArrayExprFirst,
+    ArrayExprThen,
 }
 
 #[cfg(test)]

--- a/expandable-impl/src/grammar.rs
+++ b/expandable-impl/src/grammar.rs
@@ -491,6 +491,10 @@ generate_grammar! {
             RBracket, ArrayExprFirst => AfterExpr;
             RBracket, ArrayExprThen => AfterExpr;
 
+            // [ <expr> ; <expr> ]
+            Semicolon, ArrayExprFirst => ExprStart, ArrayExprSize;
+            RBracket, ArrayExprSize => AfterExpr;
+
             RBrace, FnBlockExpr => ItemStart;
             LBrace, Condition => ExprStart, Consequence;
 
@@ -543,6 +547,10 @@ generate_grammar! {
             // [ <expr> ]
             RBracket, ArrayExprFirst => AfterExpr;
             RBracket, ArrayExprThen => AfterExpr;
+
+            // [ <expr> ; <expr> ]
+            Semicolon, ArrayExprFirst => ExprStart, ArrayExprSize;
+            RBracket, ArrayExprSize => AfterExpr;
 
             RBrace, FnBlockExpr => ItemStart;
             LBrace, Condition => ExprStart, Consequence;
@@ -640,6 +648,7 @@ pub(crate) enum StackSymbol {
     AfterFnParams,
     ArrayExprFirst,
     ArrayExprThen,
+    ArrayExprSize,
 }
 
 #[cfg(test)]

--- a/expandable-impl/src/lib.rs
+++ b/expandable-impl/src/lib.rs
@@ -759,10 +759,30 @@ mod tests {
     }
 
     check_macro_test! {
-        array_3 {
+        array_2_ {
             #[expr]
             {
                 () => { [a, b,] };
+            }
+        }
+    }
+
+    check_macro_test! {
+        array_with_fragments {
+            #[expr]
+            {
+                (#a:expr, #b:expr, #c:ident, #d:ident) => { [#a, #b, #c, #d] };
+            }
+        }
+    }
+
+    check_macro_test! {
+        array_repeat {
+            #[expr]
+            {
+                ( #a:expr, #b:expr ) => {
+                    [#a; #b]
+                };
             }
         }
     }

--- a/expandable-impl/src/lib.rs
+++ b/expandable-impl/src/lib.rs
@@ -730,4 +730,40 @@ mod tests {
             }
         }
     }
+
+    check_macro_test! {
+        array_0 {
+            #[expr]
+            {
+                () => { [] };
+            }
+        }
+    }
+
+    check_macro_test! {
+        array_1 {
+            #[expr]
+            {
+                () => { [a] };
+            }
+        }
+    }
+
+    check_macro_test! {
+        array_2 {
+            #[expr]
+            {
+                () => { [a, b] };
+            }
+        }
+    }
+
+    check_macro_test! {
+        array_3 {
+            #[expr]
+            {
+                () => { [a, b,] };
+            }
+        }
+    }
 }

--- a/expandable-impl/src/lib.rs
+++ b/expandable-impl/src/lib.rs
@@ -215,9 +215,16 @@ impl<Span> TokenTree<Span> {
         }
     }
 
-    pub fn curlyBraced(span: Span, i: Vec<TokenTree<Span>>) -> TokenTree<Span> {
+    pub fn curly_braced(span: Span, i: Vec<TokenTree<Span>>) -> TokenTree<Span> {
         TokenTree {
             kind: TokenTreeKind::CurlyBraced(i),
+            span,
+        }
+    }
+
+    pub fn bracketed(span: Span, i: Vec<TokenTree<Span>>) -> TokenTree<Span> {
+        TokenTree {
+            kind: TokenTreeKind::Bracketed(i),
             span,
         }
     }
@@ -232,6 +239,8 @@ pub enum TokenTreeKind<Span> {
     Parenthesed(Vec<TokenTree<Span>>),
     /// A sequence of [`TokenTree`] that is delimited by curly brackets.
     CurlyBraced(Vec<TokenTree<Span>>),
+    /// A sequence of [`TokenTree`] that is delimited by brackets.
+    Bracketed(Vec<TokenTree<Span>>),
 }
 
 impl_spannable!(TokenTreeKind<Span> => TokenTree);

--- a/expandable-impl/src/macros.rs
+++ b/expandable-impl/src/macros.rs
@@ -18,7 +18,11 @@ macro_rules! quote {
     };
 
     (@inner $sb:expr, { $( $tt:tt )* } ) => {
-        $crate::TokenTree::curlyBraced($sb.mk_span(), $crate::quote! { @with_sb $sb, $( $tt )* })
+        $crate::TokenTree::curly_braced($sb.mk_span(), $crate::quote! { @with_sb $sb, $( $tt )* })
+    };
+
+    (@inner $sb:expr, [ $( $tt:tt )* ] ) => {
+        $crate::TokenTree::bracketed($sb.mk_span(), $crate::quote! { @with_sb $sb, $( $tt )* })
     };
 
     // Keywords

--- a/expandable-impl/src/matcher.rs
+++ b/expandable-impl/src/matcher.rs
@@ -58,6 +58,7 @@ pub(crate) enum TokenTreeKind<Span> {
     Terminal(Terminal),
     Parenthesed(Vec<TokenTree<Span>>),
     CurlyBraced(Vec<TokenTree<Span>>),
+    Bracketed(Vec<TokenTree<Span>>),
     Binding {
         name: String,
         kind: FragmentKind,
@@ -103,7 +104,8 @@ where
                         }
 
                         GenericTokenTreeKind::Terminal(_)
-                        | GenericTokenTreeKind::CurlyBraced(_) => {
+                        | GenericTokenTreeKind::CurlyBraced(_)
+                        | GenericTokenTreeKind::Bracketed(_) => {
                             return Err(Error::ParsingFailed {
                                 what: vec![
                                     MacroRuleNode::Repetition,
@@ -127,6 +129,10 @@ where
                 GenericTokenTreeKind::CurlyBraced(inner) => {
                     TokenTreeKind::CurlyBraced(TokenTree::from_generic(inner)?)
                         .with_span(token.span)
+                }
+
+                GenericTokenTreeKind::Bracketed(inner) => {
+                    TokenTreeKind::Bracketed(TokenTree::from_generic(inner)?).with_span(token.span)
                 }
             };
 
@@ -247,7 +253,9 @@ where
                 (Some(Box::new(sep)), quantifier)
             }
 
-            GenericTokenTreeKind::Parenthesed(_) | GenericTokenTreeKind::CurlyBraced(_) => {
+            GenericTokenTreeKind::Parenthesed(_)
+            | GenericTokenTreeKind::CurlyBraced(_)
+            | GenericTokenTreeKind::Bracketed(_) => {
                 return Err(Error::ParsingFailed {
                     what: vec![
                         MacroRuleNode::RepetitionSeparator,
@@ -340,7 +348,9 @@ where
                     inner.iter().for_each(|tt| visit(bindings, &stack, tt));
                 }
 
-                TokenTreeKind::Parenthesed(inner) | TokenTreeKind::CurlyBraced(inner) => {
+                TokenTreeKind::Parenthesed(inner)
+                | TokenTreeKind::CurlyBraced(inner)
+                | TokenTreeKind::Bracketed(inner) => {
                     inner.iter().for_each(|tt| visit(bindings, stack, tt));
                 }
             }

--- a/expandable-impl/src/repetition_stack.rs
+++ b/expandable-impl/src/repetition_stack.rs
@@ -64,7 +64,9 @@ where
 {
     match &elem.kind {
         TokenTreeKind::Terminal(_, _) => Vec::new(),
-        TokenTreeKind::Parenthesed(inner) | TokenTreeKind::CurlyBraced(inner) => inner
+        TokenTreeKind::Parenthesed(inner)
+        | TokenTreeKind::CurlyBraced(inner)
+        | TokenTreeKind::Bracketed(inner) => inner
             .iter()
             .flat_map(|elem| collect_usages(elem, stack))
             .collect(),

--- a/expandable-impl/src/substitution.rs
+++ b/expandable-impl/src/substitution.rs
@@ -18,6 +18,7 @@ pub(crate) enum TokenTreeKind<Span> {
     Terminal(Terminal, TokenDescription),
     Parenthesed(Vec<TokenTree<Span>>),
     CurlyBraced(Vec<TokenTree<Span>>),
+    Bracketed(Vec<TokenTree<Span>>),
     Fragment(String),
     Repetition {
         inner: Vec<TokenTree<Span>>,
@@ -57,7 +58,8 @@ where
                         }
 
                         GenericTokenTreeKind::CurlyBraced(_)
-                        | GenericTokenTreeKind::Terminal(_) => {
+                        | GenericTokenTreeKind::Terminal(_)
+                        | GenericTokenTreeKind::Bracketed(_) => {
                             return Err(Error::ParsingFailed {
                                 what: vec![MacroRuleNode::Repetition, MacroRuleNode::FragmentName],
                                 where_: token.span,
@@ -79,6 +81,10 @@ where
                 GenericTokenTreeKind::CurlyBraced(inner) => {
                     TokenTreeKind::CurlyBraced(TokenTree::from_generic(inner)?)
                         .with_span(token.span)
+                }
+
+                GenericTokenTreeKind::Bracketed(inner) => {
+                    TokenTreeKind::Bracketed(TokenTree::from_generic(inner)?).with_span(token.span)
                 }
             };
 
@@ -145,7 +151,8 @@ where
 
                     GenericTokenTreeKind::Terminal(_)
                     | GenericTokenTreeKind::Parenthesed(_)
-                    | GenericTokenTreeKind::CurlyBraced(_) => {
+                    | GenericTokenTreeKind::CurlyBraced(_)
+                    | GenericTokenTreeKind::Bracketed(_) => {
                         return Err(Error::ParsingFailed {
                             what: vec![MacroRuleNode::RepetitionQuantifier],
                             where_: token.span,
@@ -155,7 +162,9 @@ where
 
                 (Some(t), del)
             }
-            GenericTokenTreeKind::Parenthesed(_) | GenericTokenTreeKind::CurlyBraced(_) => {
+            GenericTokenTreeKind::Parenthesed(_)
+            | GenericTokenTreeKind::CurlyBraced(_)
+            | GenericTokenTreeKind::Bracketed(_) => {
                 return Err(Error::ParsingFailed {
                     what: vec![MacroRuleNode::RepetitionQuantifier],
                     where_: token.span,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,7 +356,7 @@ fn parse_macro_stream(stream: TokenStream) -> Vec<expandable_impl::TokenTree<Spa
                 match g.delimiter() {
                     Delimiter::Parenthesis => expandable_impl::TokenTreeKind::Parenthesed(inner),
                     Delimiter::Brace => expandable_impl::TokenTreeKind::CurlyBraced(inner),
-                    Delimiter::Bracket => todo!("Need some work in the impl crate"),
+                    Delimiter::Bracket => expandable_impl::TokenTreeKind::Bracketed(inner),
                     Delimiter::None => todo!("How did we get here?"),
                 }
             }

--- a/tests/ui/fail/bad_nesting_1.rs
+++ b/tests/ui/fail/bad_nesting_1.rs
@@ -1,7 +1,7 @@
 #[expandable::expr]
 #[allow(unused_macros)]
 macro_rules! bad_nesting_example {
-    ( $( $a:ident )? ) => {
+    ($($a:ident)?) => {
         $a
     };
 }

--- a/tests/ui/fail/invalid_fn_calls.stderr
+++ b/tests/ui/fail/invalid_fn_calls.stderr
@@ -1,10 +1,10 @@
-error: Potentially invalid expansion. Expected an identifier, a literal, `if`, a `)`.
+error: Potentially invalid expansion. Expected an identifier, a literal, `if`, a `[`, a `)`.
  --> tests/ui/fail/invalid_fn_calls.rs:6:18
   |
 6 |         $fn_name(,)
   |                  ^
 
-error: Potentially invalid expansion. Expected an identifier, a literal, `if`, a `)`.
+error: Potentially invalid expansion. Expected an identifier, a literal, `if`, a `[`, a `)`.
   --> tests/ui/fail/invalid_fn_calls.rs:14:18
    |
 14 |         $fn_name(,,)

--- a/tests/ui/fail/js_concat.stderr
+++ b/tests/ui/fail/js_concat.stderr
@@ -1,4 +1,4 @@
-error: Potentially invalid expansion. Expected an identifier, a literal, `if`.
+error: Potentially invalid expansion. Expected an identifier, a literal, `if`, a `[`.
  --> tests/ui/fail/js_concat.rs:5:16
   |
 5 |         $left ++ $right

--- a/tests/ui/fail/python_power_operator.stderr
+++ b/tests/ui/fail/python_power_operator.stderr
@@ -1,4 +1,4 @@
-error: Potentially invalid expansion. Expected an identifier, a literal, `if`.
+error: Potentially invalid expansion. Expected an identifier, a literal, `if`, a `[`.
  --> tests/ui/fail/python_power_operator.rs:5:14
   |
 5 |         $e * *$e

--- a/tests/ui/pass/bracket.rs
+++ b/tests/ui/pass/bracket.rs
@@ -4,6 +4,10 @@ macro_rules! mk_array {
     ( $( $e:expr ),* $(,)? ) => {
         [ $( $e ),* ]
     };
+
+    ( $repeat:expr; $size:expr ) => {
+        [ $repeat; $size ]
+    };
 }
 
 fn main() {}

--- a/tests/ui/pass/bracket.rs
+++ b/tests/ui/pass/bracket.rs
@@ -1,0 +1,9 @@
+#[allow(unused_macros)]
+#[expandable::expr]
+macro_rules! mk_array {
+    ( $( $e:expr ),* $(,)? ) => {
+        [ $( $e ),* ]
+    };
+}
+
+fn main() {}

--- a/tests/ui/pass/if_.rs
+++ b/tests/ui/pass/if_.rs
@@ -8,19 +8,11 @@ macro_rules! if_ {
     };
 
     () => {
-        if a {
-            a
-        } else {
-            a
-        }
+        if a { a } else { a }
     };
 
     ($a:ident) => {
-        if $a {
-            $a
-        } else {
-            $a
-        }
+        if $a { $a } else { $a }
     };
 }
 


### PR DESCRIPTION
This MR adds support both for array expressions such as `[e1, e2, e3]` (an [ArrayElementConstructor]) and `[e; n]` (an [ArrayRepeatitionConstructor]). This required adding a adding a `Bracketed` variant of our various `TokenTree` data structures.

[ArrayElementConstructor]: https://spec.ferrocene.dev/expressions.html#syntax_arrayelementconstructor
[ArrayRepeatitionConstructor]: https://spec.ferrocene.dev/expressions.html#syntax_arrayrepetitionconstructor