### PR TITLE
feat: parse <expr> . <something>

### DIFF
--- a/expandable-impl/src/grammar.rs
+++ b/expandable-impl/src/grammar.rs
@@ -552,7 +552,30 @@ generate_grammar! {
 
         // <expr> .
         ExprDot {
+            // <expr> . await
             Await => AfterExpr;
+            // <expr> . <ident>
+            "ident" => FieldOrMethod;
+            Ident => FieldOrMethod;
+
+            // <expr> . decimal
+            // TODO: this is badness 10_000: this means that we accept things
+            // like `"foo"."bar"`, which is obviously not valid Rust.
+            //
+            // TODO: when the `literal` fragment is recognized, we may want to
+            // accept a $literal here as well.
+            Literal => AfterExpr;
+        },
+
+        // <expr> . <ident>
+        #[accepting]
+        FieldOrMethod(AfterExpr) {
+            // TODO: handle turbofish calls:
+            // <expr> . <ident> :: < ... > (
+
+            // Method call
+            // <expr> . <ident> (
+            LParen => ExprStart, FnArgListFirst;
         },
 
         AfterElse {

--- a/expandable-impl/src/grammar.rs
+++ b/expandable-impl/src/grammar.rs
@@ -540,11 +540,19 @@ generate_grammar! {
             // optional `else` branch.
             RBrace, Consequence => AfterIf;
             RBrace, Alternative => AfterExpr;
+
+            // <expr> .
+            Dot => ExprDot;
         },
 
         #[accepting]
         AfterIf(AfterExpr) {
             Else => AfterElse;
+        },
+
+        // <expr> .
+        ExprDot {
+            Await => AfterExpr;
         },
 
         AfterElse {

--- a/tests/ui/fail/invalid_fn_calls.stderr
+++ b/tests/ui/fail/invalid_fn_calls.stderr
@@ -10,7 +10,7 @@ error: Potentially invalid expansion. Expected an identifier, a literal, `if`, a
 14 |         $fn_name(,,)
    |                  ^
 
-error: Potentially invalid expansion. Expected `+`, `-`, `*`, `/`, `%`, `&`, `|`, `^`, `<<`, `>>`, `==`, `>`, `>=`, `<`, `<=`, `!=`, a `(`, `,`, a `)`.
+error: Potentially invalid expansion. Expected `+`, `-`, `*`, `/`, `%`, `&`, `|`, `^`, `<<`, `>>`, `==`, `>`, `>=`, `<`, `<=`, `!=`, a `(`, `,`, a `)`, `.`.
   --> tests/ui/fail/invalid_fn_calls.rs:22:25
    |
 22 |         $fn_name($arg1 $arg2)

--- a/tests/ui/pass/await.rs
+++ b/tests/ui/pass/await.rs
@@ -1,0 +1,9 @@
+#[allow(unused_macros)]
+#[expandable::expr]
+macro_rules! r#await {
+    ($e:expr) => {
+        $e.await
+    };
+}
+
+fn main() {}

--- a/tests/ui/pass/field_access.rs
+++ b/tests/ui/pass/field_access.rs
@@ -1,0 +1,17 @@
+#[allow(unused_macros)]
+#[expandable::expr]
+macro_rules! field {
+    ($e:expr, $f:ident) => {
+        $e.$f
+    };
+
+    () => {
+        "foo".bar + 1
+    };
+
+    () => {
+        "foo".0 + 1
+    };
+}
+
+fn main() {}


### PR DESCRIPTION
This MR adds support for [AwaitExpr], [FieldAccessExpression]* and [MethodCallExpression]** parsing.

*: We currently don't recognize literal fragments, so it does not handle `<expr> . $literal`
**: This does not include method call with generics - they are too scary for now >.<

[AwaitExpr]: https://spec.ferrocene.dev/expressions.html#syntax_awaitexpression
[FieldAccessExpression]: https://spec.ferrocene.dev/expressions.html#syntax_fieldaccessexpression
[MethodCallExpression]: https://spec.ferrocene.dev/expressions.html#syntax_methodcallexpression