### PR TITLE
feat: parse generics in function and method calls

### DIFF
--- a/expandable-impl/src/grammar.rs
+++ b/expandable-impl/src/grammar.rs
@@ -466,9 +466,9 @@ generate_grammar! {
     #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
     pub(crate) enum State {
         ExprStart {
-            "ident" => AfterExpr;
+            "ident" => AfterIdentExpr;
             "expr" => AfterExpr;
-            Ident => AfterExpr;
+            Ident => AfterIdentExpr;
             Literal => AfterExpr;
             If => ExprStart, Condition;
 
@@ -486,8 +486,14 @@ generate_grammar! {
             RBracket, ArrayExprThen => AfterExpr;
         },
 
+        // <ident>
         #[accepting]
-        // Transitions added here must be added in `AfterIf` as well.
+        AfterIdentExpr(AfterExpr) {
+            // <ident> ::
+            ColonColon => CallGenericArgumentList;
+        },
+
+        #[accepting]
         AfterExpr {
             // Arithmetic expressions
             // https://spec.ferrocene.dev/expressions.html#arithmetic-expressions

--- a/expandable-impl/src/grammar.rs
+++ b/expandable-impl/src/grammar.rs
@@ -476,10 +476,8 @@ generate_grammar! {
             // https://spec.ferrocene.dev/expressions.html#array-expressions
             LBracket => ExprStart, ArrayExprFirst;
 
-            // <expr> ()
-            RParen, FnArgListFirst => AfterExpr;
-            // <expr> ( <expr>, )
-            RParen, FnArgListThen => AfterExpr;
+            // <expr> ( <expr> ,)
+            RParen, FnArgList => AfterExpr;
             // []
             RBracket, ArrayExprFirst => AfterExpr;
             // [ <expr>, ]
@@ -532,15 +530,13 @@ generate_grammar! {
             LBrace, Condition => ExprStart, Consequence;
 
             // <expr> (
-            LParen => ExprStart, FnArgListFirst;
+            LParen => ExprStart, FnArgList;
             // <expr>, <expr>, ...
-            Comma, FnArgListFirst => ExprStart, FnArgListThen;
-            Comma, FnArgListThen => ExprStart, FnArgListThen;
+            Comma, FnArgList => ExprStart, FnArgList;
             Comma, ArrayExprFirst => ExprStart, ArrayExprThen;
             Comma, ArrayExprThen => ExprStart, ArrayExprThen;
             // <expr> )
-            RParen, FnArgListFirst => AfterExpr;
-            RParen, FnArgListThen => AfterExpr;
+            RParen, FnArgList => AfterExpr;
 
             // We don't continue to `AfterExpr` because we want to parse an
             // optional `else` branch.
@@ -578,7 +574,7 @@ generate_grammar! {
         FieldOrMethod(AfterExpr) {
             // Method call
             // <expr> . <ident> (
-            LParen => ExprStart, FnArgListFirst;
+            LParen => ExprStart, FnArgList;
 
             // Turbofish:
             // <expr> . <ident> ::
@@ -600,7 +596,7 @@ generate_grammar! {
         // <expr> . <ident> :: < >
         AfterMethodCallGenericParams {
             // <expr> . <ident> :: < > (
-            LParen => ExprStart, FnArgListFirst;
+            LParen => ExprStart, FnArgList;
         },
 
         AfterElse {
@@ -670,10 +666,13 @@ pub(crate) enum StackSymbol {
     Condition,
     Consequence,
     Alternative,
-    FnArgListFirst,
-    FnArgListThen,
+    FnArgList,
     FnParam,
     AfterFnParams,
+    // We have to distinguish between the first and the other elements of an
+    // array in order to detect ArrayRepetitionConstructors:
+    //
+    // https://spec.ferrocene.dev/expressions.html#syntax_arrayrepetitionconstructor
     ArrayExprFirst,
     ArrayExprThen,
     ArrayExprSize,

--- a/tests/ui/pass/fn_calls.rs
+++ b/tests/ui/pass/fn_calls.rs
@@ -12,6 +12,10 @@ macro_rules! call {
     ($fn_name:ident($($args:expr,)+)) => {
         $fn_name($($args,)+)
     };
+
+    () => {
+        foo::<bar>() + foo::<bar,>() + foo::<bar, baz,>()
+    }
 }
 
 fn main() {}

--- a/tests/ui/pass/method_chain.rs
+++ b/tests/ui/pass/method_chain.rs
@@ -1,0 +1,18 @@
+#[allow(unused_macros)]
+#[expandable::expr]
+macro_rules! chain {
+    () => {
+        foo.bar
+            .baz()
+            .qux
+            .await
+            .unwrap()
+            .conv::<u32>()
+            .conv::<u32>()
+            .conv::<u32, u32>()
+            .conv::<u32, u32, u32>()
+            .19
+    };
+}
+
+fn main() {}


### PR DESCRIPTION
#8 and #22 added support for function and method call with 0 or more arguments. This MR adds support for generic arguments using the `turbo::<fish>` syntax.

For now, we only support generic type arguments. This will be improved later.

Additionally, some occurrence of `First`- and `Then`-suffixed stack symbols were merged in order to reduce the amount of required transitions and stack symbols.