### PR TITLE
feat: parse block expressions and const generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ macro_rules! js_concat {
 
 This emits the following error [^error-message]:
 ```none
-error: Potentially invalid expansion. Expected an identifier, a literal, `if`, a `[`.
+error: Potentially invalid expansion. Expected an identifier, a literal, `if`, a `[`, a `{`.
  --> tests/ui/fail/js_concat.rs:5:16
   |
 5 |         $left ++ $right

--- a/expandable-impl/src/grammar.rs
+++ b/expandable-impl/src/grammar.rs
@@ -476,6 +476,10 @@ generate_grammar! {
             // https://spec.ferrocene.dev/expressions.html#array-expressions
             LBracket => ExprStart, ArrayExprFirst;
 
+            // Block expressions
+            // https://spec.ferrocene.dev/expressions.html#syntax_blockexpression
+            LBrace => ExprStart, BlockExpr;
+
             // <expr> ( <expr> ,)
             RParen, FnArgList => AfterExpr;
             // []
@@ -542,6 +546,9 @@ generate_grammar! {
             // optional `else` branch.
             RBrace, Consequence => AfterIf;
             RBrace, Alternative => AfterExpr;
+
+            // { <expr> }
+            RBrace, BlockExpr => AfterExpr;
 
             // <expr> .
             Dot => ExprDot;
@@ -677,4 +684,5 @@ pub(crate) enum StackSymbol {
     ArrayExprThen,
     ArrayExprSize,
     CallGenerics,
+    BlockExpr,
 }

--- a/expandable-impl/src/grammar.rs
+++ b/expandable-impl/src/grammar.rs
@@ -549,6 +549,7 @@ generate_grammar! {
 
             // { <expr> }
             RBrace, BlockExpr => AfterExpr;
+            RBrace, GenericBlockExpr => AfterGenericExpr;
 
             // <expr> .
             Dot => ExprDot;
@@ -597,11 +598,28 @@ generate_grammar! {
         // <expr> . <ident> :: <
         GenericStart(TypeStart) {
             // <expr> . <ident> :: < >
-            GreaterThan, CallGenerics => AfterMethodCallGenericParams;
+            GreaterThan, CallGenerics => AfterCallGenericParams;
+            // <expr> . <ident> :: < { <expr> } >
+            LBrace => ExprStart, GenericBlockExpr;
+            // <expr> . <ident> :: < literal >
+            Literal => AfterGenericExpr;
+            // <expr> . <ident> :: < - <literal> >
+            Minus => GenericLiteralExpr;
+        },
+
+        // <expr> . <ident> :: < - <literal> >
+        GenericLiteralExpr {
+            Literal => AfterGenericExpr;
+        },
+
+        // <expr> . <ident> :: < { <expr> }
+        AfterGenericExpr {
+            Comma => GenericStart;
+            GreaterThan, CallGenerics => AfterCallGenericParams;
         },
 
         // <expr> . <ident> :: < >
-        AfterMethodCallGenericParams {
+        AfterCallGenericParams {
             // <expr> . <ident> :: < > (
             LParen => ExprStart, FnArgList;
         },
@@ -652,7 +670,7 @@ generate_grammar! {
             // fn_name :: < <type> ,
             Comma, CallGenerics => GenericStart, CallGenerics;
             // fn_name :: < <type> >
-            GreaterThan, CallGenerics => AfterMethodCallGenericParams;
+            GreaterThan, CallGenerics => AfterCallGenericParams;
         },
     }
 }
@@ -685,4 +703,5 @@ pub(crate) enum StackSymbol {
     ArrayExprSize,
     CallGenerics,
     BlockExpr,
+    GenericBlockExpr,
 }

--- a/tests/ui/fail/invalid_fn_calls.stderr
+++ b/tests/ui/fail/invalid_fn_calls.stderr
@@ -1,10 +1,10 @@
-error: Potentially invalid expansion. Expected an identifier, a literal, `if`, a `[`, a `)`.
+error: Potentially invalid expansion. Expected an identifier, a literal, `if`, a `[`, a `{`, a `)`.
  --> tests/ui/fail/invalid_fn_calls.rs:6:18
   |
 6 |         $fn_name(,)
   |                  ^
 
-error: Potentially invalid expansion. Expected an identifier, a literal, `if`, a `[`, a `)`.
+error: Potentially invalid expansion. Expected an identifier, a literal, `if`, a `[`, a `{`, a `)`.
   --> tests/ui/fail/invalid_fn_calls.rs:14:18
    |
 14 |         $fn_name(,,)

--- a/tests/ui/fail/js_concat.stderr
+++ b/tests/ui/fail/js_concat.stderr
@@ -1,4 +1,4 @@
-error: Potentially invalid expansion. Expected an identifier, a literal, `if`, a `[`.
+error: Potentially invalid expansion. Expected an identifier, a literal, `if`, a `[`, a `{`.
  --> tests/ui/fail/js_concat.rs:5:16
   |
 5 |         $left ++ $right

--- a/tests/ui/fail/python_power_operator.stderr
+++ b/tests/ui/fail/python_power_operator.stderr
@@ -1,4 +1,4 @@
-error: Potentially invalid expansion. Expected an identifier, a literal, `if`, a `[`.
+error: Potentially invalid expansion. Expected an identifier, a literal, `if`, a `[`, a `{`.
  --> tests/ui/fail/python_power_operator.rs:5:14
   |
 5 |         $e * *$e

--- a/tests/ui/pass/block.rs
+++ b/tests/ui/pass/block.rs
@@ -2,6 +2,10 @@
 #[expandable::expr]
 macro_rules! block {
     ($e:expr) => {{ $e }};
+
+    () => {
+        { 1 } + { 2 } == { 3 }
+    }
 }
 
 fn main() {}

--- a/tests/ui/pass/block.rs
+++ b/tests/ui/pass/block.rs
@@ -1,0 +1,7 @@
+#[allow(unused_macros)]
+#[expandable::expr]
+macro_rules! block {
+    ($e:expr) => {{ $e }};
+}
+
+fn main() {}

--- a/tests/ui/pass/fn_calls.rs
+++ b/tests/ui/pass/fn_calls.rs
@@ -15,7 +15,11 @@ macro_rules! call {
 
     () => {
         foo::<bar>() + foo::<bar,>() + foo::<bar, baz,>()
-    }
+    };
+
+    () => {
+        foo::<{bar}, -1, 1, foo>()
+    };
 }
 
 fn main() {}


### PR DESCRIPTION
This PR adds support for [BlockExpression]* **, and its parsing in generic argument context. In addition, literals (optionally prefixed by `-`) are parsed in generic arguments.

*: does not include labels
**: we still don't handle statements, it is just `{ <expr> }` actually.

[BlockExpression]: https://spec.ferrocene.dev/expressions.html#syntax_blockexpression