### PR TITLE
fix: honour newer rustc/clippy warnings

### DIFF
--- a/expandable-impl/src/error.rs
+++ b/expandable-impl/src/error.rs
@@ -125,7 +125,7 @@ pub enum MacroRuleNode {
     MetaVariableMatch,
     /// A repetition quantifier (`?`, `*`, `+`).
     RepetitionQuantifier,
-    /// A repetition separator (the `,` in `$( $expr ),*.
+    /// A repetition separator (the `,` in `$( $expr ),*`).
     RepetitionSeparator,
     /// Any terminal.
     Terminal(Terminal),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,18 +52,11 @@
 
 extern crate proc_macro;
 
-use std::{
-    fmt::{Display, Formatter},
-    str::FromStr,
-};
+use std::fmt::{Display, Formatter};
 
 use expandable_impl::{RepetitionQuantifierKind, Terminal, TokenDescription};
 use proc_macro::TokenStream as TokenStream1;
 use proc_macro2::{Delimiter, Spacing, Span, TokenStream, TokenTree};
-use syn::{
-    parse::{Parse, ParseStream},
-    Ident,
-};
 use syn_shim::ItemMacroRules;
 
 mod syn_shim;
@@ -507,23 +500,6 @@ fn parse_punctuation(mut input: &[TokenTree]) -> Option<(Span, Terminal, &[Token
     }
 
     current.map(|(span, terminal)| (span, terminal, input))
-}
-
-struct InvocationContext(expandable_impl::InvocationContext);
-
-impl Parse for InvocationContext {
-    fn parse(input: ParseStream) -> syn::Result<InvocationContext> {
-        let ident = input.parse::<Ident>()?;
-
-        expandable_impl::InvocationContext::from_str(&ident.to_string())
-            .map(InvocationContext)
-            .map_err(|()| {
-                syn::Error::new(
-                    ident.span(),
-                    "Unknown invocation context. Expected `item` or `expr`",
-                )
-            })
-    }
 }
 
 #[cfg(test)]

--- a/src/syn_shim.rs
+++ b/src/syn_shim.rs
@@ -74,9 +74,9 @@ impl Attribute {
 fn parse_delimited(input: ParseStream) -> syn::Result<(MacroDelimiter, TokenStream)> {
     let (delim, span, inner) = input.parse_any_delimiter()?;
     let delim = match delim {
-        Delimiter::Parenthesis => MacroDelimiter(span),
-        Delimiter::Brace => MacroDelimiter(span),
-        Delimiter::Bracket => MacroDelimiter(span),
+        Delimiter::Parenthesis => MacroDelimiter { _inner: span },
+        Delimiter::Brace => MacroDelimiter { _inner: span },
+        Delimiter::Bracket => MacroDelimiter { _inner: span },
         Delimiter::None => {
             return Err(syn::Error::new(
                 span.join(),
@@ -90,7 +90,9 @@ fn parse_delimited(input: ParseStream) -> syn::Result<(MacroDelimiter, TokenStre
     Ok((delim, inner))
 }
 
-struct MacroDelimiter(DelimSpan);
+struct MacroDelimiter {
+    _inner: DelimSpan,
+}
 
 mod inner {
     // The `custom_keyword` macro defines a `pub` item, which is not allowed at


### PR DESCRIPTION
I shouldn't have left the codebase for this long :/