### PR TITLE
feat: sort expected tokens lexicographically before printing them

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ macro_rules! js_concat {
 
 This emits the following error [^error-message]:
 ```none
-error: Potentially invalid expansion. Expected an identifier, a literal, `if`, a `[`, a `{`, `break`, `return`.
+error: Potentially invalid expansion. Expected `break`, `if`, `return`, a `[`, a `{`, a literal, an identifier.
  --> tests/ui/fail/js_concat.rs:5:16
   |
 5 |         $left ++ $right

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,9 @@ fn mk_error_msg(error: expandable_impl::Error<Span>) -> syn::Error {
         }
 
         expandable_impl::Error::InvalidProducedAst { span, expected, .. } => {
-            let expected = expected.iter().map(describe).collect::<Vec<_>>().join(", ");
+            let mut expected = expected.iter().map(describe).collect::<Vec<_>>();
+            expected.sort_unstable();
+            let expected = expected.join(", ");
             (
                 format!("Potentially invalid expansion. Expected {expected}."),
                 Some(span),

--- a/tests/ui/fail/fn_args.stderr
+++ b/tests/ui/fail/fn_args.stderr
@@ -1,10 +1,10 @@
-error: Potentially invalid expansion. Expected an identifier, a `)`.
+error: Potentially invalid expansion. Expected a `)`, an identifier.
  --> tests/ui/fail/fn_args.rs:5:17
   |
 5 |         fn test(,) -> u8 {
   |                 ^
 
-error: Potentially invalid expansion. Expected an identifier, a `)`.
+error: Potentially invalid expansion. Expected a `)`, an identifier.
   --> tests/ui/fail/fn_args.rs:15:23
    |
 15 |         fn test(a: u8,,) -> u8 {

--- a/tests/ui/fail/invalid_fn_calls.stderr
+++ b/tests/ui/fail/invalid_fn_calls.stderr
@@ -1,16 +1,16 @@
-error: Potentially invalid expansion. Expected an identifier, a literal, `if`, a `[`, a `{`, a `)`, `break`, `return`.
+error: Potentially invalid expansion. Expected `break`, `if`, `return`, a `)`, a `[`, a `{`, a literal, an identifier.
  --> tests/ui/fail/invalid_fn_calls.rs:6:18
   |
 6 |         $fn_name(,)
   |                  ^
 
-error: Potentially invalid expansion. Expected an identifier, a literal, `if`, a `[`, a `{`, a `)`, `break`, `return`.
+error: Potentially invalid expansion. Expected `break`, `if`, `return`, a `)`, a `[`, a `{`, a literal, an identifier.
   --> tests/ui/fail/invalid_fn_calls.rs:14:18
    |
 14 |         $fn_name(,,)
    |                  ^
 
-error: Potentially invalid expansion. Expected `+`, `-`, `*`, `/`, `%`, `&`, `|`, `^`, `<<`, `>>`, `==`, `>`, `>=`, `<`, `<=`, `!=`, a `(`, `,`, a `)`, `.`.
+error: Potentially invalid expansion. Expected `!=`, `%`, `&`, `*`, `+`, `,`, `-`, `.`, `/`, `<<`, `<=`, `<`, `==`, `>=`, `>>`, `>`, `^`, `|`, a `(`, a `)`.
   --> tests/ui/fail/invalid_fn_calls.rs:22:25
    |
 22 |         $fn_name($arg1 $arg2)

--- a/tests/ui/fail/js_concat.stderr
+++ b/tests/ui/fail/js_concat.stderr
@@ -1,4 +1,4 @@
-error: Potentially invalid expansion. Expected an identifier, a literal, `if`, a `[`, a `{`, `break`, `return`.
+error: Potentially invalid expansion. Expected `break`, `if`, `return`, a `[`, a `{`, a literal, an identifier.
  --> tests/ui/fail/js_concat.rs:5:16
   |
 5 |         $left ++ $right

--- a/tests/ui/fail/python_power_operator.stderr
+++ b/tests/ui/fail/python_power_operator.stderr
@@ -1,4 +1,4 @@
-error: Potentially invalid expansion. Expected an identifier, a literal, `if`, a `[`, a `{`, `break`, `return`.
+error: Potentially invalid expansion. Expected `break`, `if`, `return`, a `[`, a `{`, a literal, an identifier.
  --> tests/ui/fail/python_power_operator.rs:5:14
   |
 5 |         $e * *$e


### PR DESCRIPTION
This MR sorts the "expected XXX, YYY, ZZZ" list printed by the `expandable` proc macro so that its ordering does not depend on how the grammar is defined. This will make the transition to the compiled parser smoother (#29).

The sorting algorithm (lexicographic order) is far from perfect, but we just need to have something vaguely deterministic for now.