### PR TITLE
feat: add support for logic and, or and range expressions

### DIFF
--- a/expandable-impl/src/grammar.rs
+++ b/expandable-impl/src/grammar.rs
@@ -523,6 +523,8 @@ generate_grammar! {
             Caret => ExprStart;
             Shl => ExprStart;
             Shr => ExprStart;
+            AndAnd => ExprStart;
+            OrOr => ExprStart;
 
             // Comparison expressions
             // https://spec.ferrocene.dev/expressions.html#comparison-expressions
@@ -532,6 +534,10 @@ generate_grammar! {
             LessThan => ExprStart;
             LessThanEquals => ExprStart;
             NotEquals => ExprStart;
+
+            // Range expressions
+            DotDot => ExprStart;
+            DotDotEquals => ExprStart;
 
             // [ <expr> ]
             RBracket, ArrayExprFirst => AfterExpr;

--- a/tests/ui/fail/invalid_fn_calls.stderr
+++ b/tests/ui/fail/invalid_fn_calls.stderr
@@ -10,7 +10,7 @@ error: Potentially invalid expansion. Expected `break`, `if`, `return`, a `)`, a
 14 |         $fn_name(,,)
    |                  ^
 
-error: Potentially invalid expansion. Expected `!=`, `%`, `&`, `*`, `+`, `,`, `-`, `.`, `/`, `<<`, `<=`, `<`, `==`, `>=`, `>>`, `>`, `^`, `|`, a `(`, a `)`.
+error: Potentially invalid expansion. Expected `!=`, `%`, `&&`, `&`, `*`, `+`, `,`, `-`, `..=`, `..`, `.`, `/`, `<<`, `<=`, `<`, `==`, `>=`, `>>`, `>`, `^`, `|`, `||`, a `(`, a `)`.
   --> tests/ui/fail/invalid_fn_calls.rs:22:25
    |
 22 |         $fn_name($arg1 $arg2)

--- a/tests/ui/pass/range_expr.rs
+++ b/tests/ui/pass/range_expr.rs
@@ -1,6 +1,6 @@
 #[allow(unused_macros)]
 #[expandable::expr]
-macro_rules! if_ {
+macro_rules! range_expr {
     () => {
         0..42
     };

--- a/tests/ui/pass/range_expr.rs
+++ b/tests/ui/pass/range_expr.rs
@@ -1,0 +1,13 @@
+#[allow(unused_macros)]
+#[expandable::expr]
+macro_rules! if_ {
+    () => {
+        0..42
+    };
+
+    () => {
+        f(a)..=g(b)
+    };
+}
+
+fn main() {}


### PR DESCRIPTION
This adds support for `||`, `&&`, `..` and `..=` operators.

This is the last piece of grammar that is required for a 100% seamless transition, as defined in #29.