### PR TITLE
test: check that generated.rs is up to date in the CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -133,3 +133,21 @@ jobs:
 
       - name: Compare README with crate-level documentation
         run: cat target/doc/expandable.json | jq ".index[.root].docs" -r | cmp README.md -
+
+  grammar-check:
+    runs-on: ubuntu-latest
+
+    env:
+      CARGO_TERM_COLOR: always
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install toolchain
+        run: rustup toolchain install nightly
+
+      - name: Generate a new generated.rs file
+        run: cargo run -p grammar-gen -- rust-grammar-dpdfa/grammar.rs generated.rs
+
+      - name: Compare new generated.rs file with HEAD
+        run: cmp rust-grammar-dpdfa/src/generated.rs generated.rs

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -146,6 +146,9 @@ jobs:
       - name: Install toolchain
         run: rustup toolchain install nightly
 
+      - name: Install nightly rustfmt
+        run: rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
+
       - name: Generate a new generated.rs file
         run: cargo +nightly run -p grammar-gen -- rust-grammar-dpdfa/grammar.rs generated.rs
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -147,7 +147,7 @@ jobs:
         run: rustup toolchain install nightly
 
       - name: Generate a new generated.rs file
-        run: cargo run -p grammar-gen -- rust-grammar-dpdfa/grammar.rs generated.rs
+        run: cargo +nightly run -p grammar-gen -- rust-grammar-dpdfa/grammar.rs generated.rs
 
       - name: Compare new generated.rs file with HEAD
-        run: cmp rust-grammar-dpdfa/src/generated.rs generated.rs
+        run: cmp -l rust-grammar-dpdfa/src/generated.rs generated.rs


### PR DESCRIPTION
Let's avoid forgetting to update `rust-grammar-dpdfa/src/generated.rs` by adding a little bit of CI.