### PR TITLE
feat: avoid printing a comically large amount of tokens on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ macro_rules! js_concat {
 
 This emits the following error [^error-message]:
 ```none
-error: Potentially invalid expansion. Expected `::`, `break`, `if`, `return`, a `[`, a `{`, a literal, an identifier.
+error: Potentially invalid expansion. Expected `::`, `break`, `if`, `return`, a `[`, a `{` or 2 others.
  --> tests/ui/fail/js_concat.rs:5:16
   |
 5 |         $left ++ $right

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,9 +107,21 @@ fn mk_error_msg(error: expandable_impl::Error<Span>) -> syn::Error {
         expandable_impl::Error::InvalidProducedAst { span, expected, .. } => {
             let mut expected = expected.iter().map(describe).collect::<Vec<_>>();
             expected.sort_unstable();
-            let expected = expected.join(", ");
+
+            let expected_len = expected.len();
+            let (actually_printed, or_n_others) = if expected_len > 6 {
+                let n = expected_len - 6;
+                let actually_printed = expected[0..6].join(", ");
+                let s = if n > 1 { "s" } else { "" };
+                let or_n_others = format!(" or {n} other{s}");
+
+                (actually_printed, or_n_others)
+            } else {
+                (expected.join(", "), String::new())
+            };
+
             (
-                format!("Potentially invalid expansion. Expected {expected}."),
+                format!("Potentially invalid expansion. Expected {actually_printed}{or_n_others}."),
                 Some(span),
             )
         }

--- a/tests/ui/fail/invalid_fn_calls.stderr
+++ b/tests/ui/fail/invalid_fn_calls.stderr
@@ -1,16 +1,16 @@
-error: Potentially invalid expansion. Expected `::`, `break`, `if`, `return`, a `)`, a `[`, a `{`, a literal, an identifier.
+error: Potentially invalid expansion. Expected `::`, `break`, `if`, `return`, a `)`, a `[` or 3 others.
  --> tests/ui/fail/invalid_fn_calls.rs:6:18
   |
 6 |         $fn_name(,)
   |                  ^
 
-error: Potentially invalid expansion. Expected `::`, `break`, `if`, `return`, a `)`, a `[`, a `{`, a literal, an identifier.
+error: Potentially invalid expansion. Expected `::`, `break`, `if`, `return`, a `)`, a `[` or 3 others.
   --> tests/ui/fail/invalid_fn_calls.rs:14:18
    |
 14 |         $fn_name(,,)
    |                  ^
 
-error: Potentially invalid expansion. Expected `!=`, `%`, `&&`, `&`, `*`, `+`, `,`, `-`, `..=`, `..`, `.`, `/`, `<<`, `<=`, `<`, `==`, `>=`, `>>`, `>`, `^`, `|`, `||`, a `(`, a `)`.
+error: Potentially invalid expansion. Expected `!=`, `%`, `&&`, `&`, `*`, `+` or 18 others.
   --> tests/ui/fail/invalid_fn_calls.rs:22:25
    |
 22 |         $fn_name($arg1 $arg2)

--- a/tests/ui/fail/js_concat.stderr
+++ b/tests/ui/fail/js_concat.stderr
@@ -1,4 +1,4 @@
-error: Potentially invalid expansion. Expected `::`, `break`, `if`, `return`, a `[`, a `{`, a literal, an identifier.
+error: Potentially invalid expansion. Expected `::`, `break`, `if`, `return`, a `[`, a `{` or 2 others.
  --> tests/ui/fail/js_concat.rs:5:16
   |
 5 |         $left ++ $right

--- a/tests/ui/fail/python_power_operator.stderr
+++ b/tests/ui/fail/python_power_operator.stderr
@@ -1,4 +1,4 @@
-error: Potentially invalid expansion. Expected `::`, `break`, `if`, `return`, a `[`, a `{`, a literal, an identifier.
+error: Potentially invalid expansion. Expected `::`, `break`, `if`, `return`, a `[`, a `{` or 2 others.
  --> tests/ui/fail/python_power_operator.rs:5:14
   |
 5 |         $e * *$e


### PR DESCRIPTION
The previous error reporting mechanism was just "print all expected tokens, separated by commas". This led to situations where a comically high amount of tokens were written in the error message. For instance:

```
error: Potentially invalid expansion. Expected `!=`, `%`, `&&`, `&`, `*`, `+`, `,`, `-`, `..=`, `..`, `.`, `/`, `<<`, `<=`, `<`, `==`, `>=`, `>>`, `>`, `^`, `|`, `||`, a `(`, a `)`.
  --> tests/ui/fail/invalid_fn_calls.rs:22:25
   |
22 |         $fn_name($arg1 $arg2)
   |                         ^^^^
```

This PR limits the amount of _printed_ tokens to 6 and adds a potential "and _n_ other_s_" if needed. This changes the error message to:

```
error: Potentially invalid expansion. Expected `!=`, `%`, `&&`, `&`, `*`, `+` or 18 others.
  --> tests/ui/fail/invalid_fn_calls.rs:22:25
   |
22 |         $fn_name($arg1 $arg2)
   |                         ^^^^
```

Which is way clearer.

The threshold value may need to be tweaked.