### PR TITLE
feat: rework ordering in the "expected XXX, YYY, ZZZ" error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ macro_rules! js_concat {
 
 This emits the following error [^error-message]:
 ```none
-error: Potentially invalid expansion. Expected `::`, `break`, `for`, `if`, `loop`, `return` or 6 others.
+error: Potentially invalid expansion. Expected an expression, an identifier, `::`, `break`, `for`, `if` or 7 others.
  --> tests/ui/fail/js_concat.rs:5:16
   |
 5 |         $left ++ $right

--- a/expandable-impl/src/grammar.rs
+++ b/expandable-impl/src/grammar.rs
@@ -170,6 +170,27 @@ macro_rules! token_description {
                         rust_grammar_dpdfa::TokenDescription::LBrace => TokenDescription::LBrace,
                         rust_grammar_dpdfa::TokenDescription::RBrace => TokenDescription::RBrace,
 
+                        // TODO: support block
+                        // rust_grammar_dpdfa::TokenDescription::FragmentBlock => TokenDescription::Fragment(FragmentKind::Block),
+                        rust_grammar_dpdfa::TokenDescription::FragmentExpr => TokenDescription::Fragment(FragmentKind::Expr),
+                        rust_grammar_dpdfa::TokenDescription::FragmentIdent => TokenDescription::Fragment(FragmentKind::Ident),
+                        rust_grammar_dpdfa::TokenDescription::FragmentItem => TokenDescription::Fragment(FragmentKind::Item),
+                        // TODO: support lifetime
+                        // rust_grammar_dpdfa::TokenDescription::FragmentLifetime => TokenDescription::Fragment(FragmentKind::Lifetime),
+                        // TODO: support literal
+                        // rust_grammar_dpdfa::TokenDescription::FragmentLiteral => TokenDescription::Fragment(FragmentKind::Literal),
+                        // TODO: support meta
+                        // rust_grammar_dpdfa::TokenDescription::FragmentMeta => TokenDescription::Fragment(FragmentKind::Meta),
+                        // TODO: support stmt
+                        // rust_grammar_dpdfa::TokenDescription::FragmentStmt => TokenDescription::Fragment(FragmentKind::Stmt),
+                        // TODO: support TT
+                        // rust_grammar_dpdfa::TokenDescription::FragmentTT => TokenDescription::Fragment(FragmentKind::TT),
+                        // TODO: support ty
+                        // rust_grammar_dpdfa::TokenDescription::FragmentTy => TokenDescription::Fragment(FragmentKind::Ty),
+                        // TODO: support vis
+                        // rust_grammar_dpdfa::TokenDescription::FragmentVis => TokenDescription::Fragment(FragmentKind::Vis),
+
+
                         _ => return Err(()),
                     }
 

--- a/tests/ui/fail/expr-tuple.stderr
+++ b/tests/ui/fail/expr-tuple.stderr
@@ -1,16 +1,16 @@
-error: Potentially invalid expansion. Expected `::`, `break`, `for`, `if`, `loop`, `return` or 7 others.
+error: Potentially invalid expansion. Expected an expression, an identifier, `::`, `break`, `for`, `if` or 8 others.
  --> tests/ui/fail/expr-tuple.rs:6:10
   |
 6 |         (,)
   |          ^
 
-error: Potentially invalid expansion. Expected `::`, `break`, `for`, `if`, `loop`, `return` or 7 others.
+error: Potentially invalid expansion. Expected an expression, an identifier, `::`, `break`, `for`, `if` or 8 others.
   --> tests/ui/fail/expr-tuple.rs:13:13
    |
 13 |         (42,, 42)
    |             ^
 
-error: Potentially invalid expansion. Expected `!=`, `%`, `&&`, `&`, `*`, `+` or 21 others.
+error: Potentially invalid expansion. Expected `!=`, `%`, `&&`, `&`, `*`, `+` or 20 others.
   --> tests/ui/fail/expr-tuple.rs:20:12
    |
 20 |         (a b)

--- a/tests/ui/fail/fn_args.stderr
+++ b/tests/ui/fail/fn_args.stderr
@@ -1,10 +1,10 @@
-error: Potentially invalid expansion. Expected a `)`, an identifier.
+error: Potentially invalid expansion. Expected an identifier, a `)`.
  --> tests/ui/fail/fn_args.rs:5:17
   |
 5 |         fn test(,) -> u8 {
   |                 ^
 
-error: Potentially invalid expansion. Expected a `)`, an identifier.
+error: Potentially invalid expansion. Expected an identifier, a `)`.
   --> tests/ui/fail/fn_args.rs:15:23
    |
 15 |         fn test(a: u8,,) -> u8 {

--- a/tests/ui/fail/invalid_fn_calls.stderr
+++ b/tests/ui/fail/invalid_fn_calls.stderr
@@ -1,10 +1,10 @@
-error: Potentially invalid expansion. Expected `::`, `break`, `for`, `if`, `loop`, `return` or 7 others.
+error: Potentially invalid expansion. Expected an expression, an identifier, `::`, `break`, `for`, `if` or 8 others.
  --> tests/ui/fail/invalid_fn_calls.rs:6:18
   |
 6 |         $fn_name(,)
   |                  ^
 
-error: Potentially invalid expansion. Expected `::`, `break`, `for`, `if`, `loop`, `return` or 7 others.
+error: Potentially invalid expansion. Expected an expression, an identifier, `::`, `break`, `for`, `if` or 8 others.
   --> tests/ui/fail/invalid_fn_calls.rs:14:18
    |
 14 |         $fn_name(,,)

--- a/tests/ui/fail/loops.stderr
+++ b/tests/ui/fail/loops.stderr
@@ -4,7 +4,7 @@ error: Potentially invalid expansion. Expected a `{`.
 6 |         loop loop {}
   |              ^^^^
 
-error: Potentially invalid expansion. Expected `::`, `break`, `for`, `if`, `loop`, `return` or 6 others.
+error: Potentially invalid expansion. Expected an expression, an identifier, `::`, `break`, `for`, `if` or 7 others.
   --> tests/ui/fail/loops.rs:13:15
    |
 13 |         while < 42 {}

--- a/tests/ui/fail/missing_expr.rs
+++ b/tests/ui/fail/missing_expr.rs
@@ -1,0 +1,10 @@
+#![allow(unused)]
+
+#[expandable::expr]
+macro_rules! test {
+    () => {{
+        let a = ;
+    }}
+}
+
+fn main() {}

--- a/tests/ui/fail/missing_expr.stderr
+++ b/tests/ui/fail/missing_expr.stderr
@@ -1,5 +1,5 @@
 error: Potentially invalid expansion. Expected an expression, an identifier, `::`, `break`, `for`, `if` or 7 others.
- --> tests/ui/fail/js_concat.rs:5:16
+ --> tests/ui/fail/missing_expr.rs:6:17
   |
-5 |         $left ++ $right
-  |                ^
+6 |         let a = ;
+  |                 ^

--- a/tests/ui/fail/path.stderr
+++ b/tests/ui/fail/path.stderr
@@ -1,16 +1,16 @@
-error: Potentially invalid expansion. Expected `Self`, an identifier.
+error: Potentially invalid expansion. Expected an identifier, `Self`.
  --> tests/ui/fail/path.rs:6:15
   |
 6 |         path:::<foo>
   |               ^
 
-error: Potentially invalid expansion. Expected `-`, `>`, a `{`, a literal, an identifier, an identifier.
+error: Potentially invalid expansion. Expected an identifier, `-`, `>`, a `{`, a literal.
   --> tests/ui/fail/path.rs:13:17
    |
 13 |         path::< <foo> >
    |                 ^
 
-error: Potentially invalid expansion. Expected `Self`, an identifier.
+error: Potentially invalid expansion. Expected an identifier, `Self`.
   --> tests/ui/fail/path.rs:20:15
    |
 20 |         path::1

--- a/tests/ui/fail/python_power_operator.stderr
+++ b/tests/ui/fail/python_power_operator.stderr
@@ -1,4 +1,4 @@
-error: Potentially invalid expansion. Expected `::`, `break`, `for`, `if`, `loop`, `return` or 6 others.
+error: Potentially invalid expansion. Expected an expression, an identifier, `::`, `break`, `for`, `if` or 7 others.
  --> tests/ui/fail/python_power_operator.rs:5:14
   |
 5 |         $e * *$e


### PR DESCRIPTION
Previously, the six first expected tokens were printed in alphabetical order, and fragment kinds were completely removed from the error message.

This was bad, because fragment kinds are high-level language constructs that help make the error message clearer. One prefers reading "`expected pattern, a literal, ::, +, -, ...`" rather than reading "`expected `::, +, -, ...`.

This MR changes how the error messages are printed such that:
- Fragment kinds are printed,
- They are printed before the other "regular" `TokenDescription`s.