### PR TITLE
refactor: use opaque type to represent state in transitions

### DIFF
--- a/grammar-gen/src/mir.rs
+++ b/grammar-gen/src/mir.rs
@@ -183,7 +183,7 @@ impl Production {
                 let then = then.into_iter().rev();
 
                 quote! {
-                    input.bump_expect(#descr, &[ #( (#then, stringify!(#then)) ),* ])
+                    input.bump_expect(#descr, &[ #( #then ),* ])
                 }
             }
 
@@ -199,7 +199,7 @@ impl Production {
                 let then = then.into_iter().rev();
 
                 quote! {
-                    input.call_now( &[ #( (#then, stringify!(#then)) ),* ])
+                    input.call_now( &[ #( #then ),* ])
                 }
             }
 
@@ -218,9 +218,9 @@ impl Production {
 
                 quote! {
                     if #( input.#builtins )||* {
-                        input.call_now(&[ #( (#cons, stringify!(#cons)) ),* ])
+                        input.call_now(&[ #( #cons ),* ])
                     } else {
-                        input.call_now(&[ #( (#alt, stringify!(#alt)) ),* ])
+                        input.call_now(&[ #( #alt ),* ])
                     }
                 }
             }


### PR DESCRIPTION
In `rust-grammar-dpdfa`, we represent the states pushed during a transition as `&'static str`. This is not perfect, because 1. comparing/hashing two strings ain't cheap and 2. we leak the state names to the library user.

This has been fixed by using a custom opaque type that contains a raw pointer corresponding to the state itself.