### PR TITLE
feat: generate a possible invalid expansion when an error is found

### DIFF
--- a/expandable-impl/src/error.rs
+++ b/expandable-impl/src/error.rs
@@ -55,7 +55,9 @@ pub enum Error<Span> {
         span: Span,
         /// What tokens are expected here.
         expected: Vec<TokenDescription>,
-        /// Counterexample!!!
+        /// A possible expansion of the macro that exhibits a parsing error.
+        ///
+        /// The expansion may contain fragments.
         counter_example: Vec<(TokenDescription, Span)>,
     },
 

--- a/expandable-impl/src/error.rs
+++ b/expandable-impl/src/error.rs
@@ -55,6 +55,8 @@ pub enum Error<Span> {
         span: Span,
         /// What tokens are expected here.
         expected: Vec<TokenDescription>,
+        /// Counterexample!!!
+        counter_example: Vec<(TokenDescription, Span)>,
     },
 
     /// A macro expansion refers to a metavariable that is not defined in the

--- a/expandable-impl/src/expansion.rs
+++ b/expandable-impl/src/expansion.rs
@@ -61,7 +61,11 @@ where
             .into_iter()
             .try_for_each(|(mut state, _, _)| state.is_accepting())
             .map_err(|e| match e {
-                Some((span, expected)) => Error::InvalidProducedAst { span, expected },
+                Some((span, expected, cex)) => Error::InvalidProducedAst {
+                    span,
+                    expected,
+                    counter_example: cex,
+                },
                 None => Error::UnexpectedEnd {
                     last_token: subst.last().map(|t| t.span),
                 },
@@ -88,7 +92,7 @@ where
         &self,
         states: Set<(DynamicState<Span>, Id)>,
         tree: &TokenTree<Span>,
-    ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
+    ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, CounterExamplePrefix<Span>>
     where
         Id: Clone + Ord,
     {
@@ -119,14 +123,14 @@ where
         state: DynamicState<Span>,
         tree: &TokenTree<Span>,
         id: Id,
-    ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
+    ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, CounterExamplePrefix<Span>>
     where
         Id: Clone + Ord,
     {
         match &tree.kind {
             TokenTreeKind::Terminal(_, descr) => state
                 .accept(*descr, tree.span)
-                .map_err(|(span, expected)| Error::InvalidProducedAst { span, expected })
+                .map_err(|(span, expected, cex)| CounterExamplePrefix::new(span, expected, cex))
                 .map(|(s, t)| (s, t, id))
                 .map(singleton),
 
@@ -165,7 +169,7 @@ where
                     .accept_fragment(kind, tree.span)
                     .map(|(s, t)| (s, t, id))
                     .map(singleton)
-                    .map_err(|(span, expected)| Error::InvalidProducedAst { span, expected })
+                    .map_err(|(span, expected, cex)| CounterExamplePrefix::new(span, expected, cex))
             }
 
             TokenTreeKind::Repetition { .. } => {
@@ -182,7 +186,7 @@ where
         span: Span,
         initial_state: DynamicState<Span>,
         id: Id,
-    ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
+    ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, CounterExamplePrefix<Span>>
     where
         Id: Clone + Ord,
     {
@@ -190,9 +194,21 @@ where
         let (s_after_open_delim, t_after_open_delim) = initial_state
             .clone()
             .accept(open, span)
-            .map_err(|(span, expected)| Error::InvalidProducedAst { span, expected })?;
+            .map_err(|(span, expected, cex)| {
+                let mut cex = CounterExamplePrefix::new(span, expected, cex);
+                cex.push_stream(inner);
+                cex.push(close, span);
 
-        let states = self.parse_stream(singleton((s_after_open_delim, id)), inner)?;
+                cex
+            })?;
+
+        let states = self
+            .parse_stream(singleton((s_after_open_delim, id)), inner)
+            .map_err(|mut cex| {
+                cex.push(close, span);
+                cex
+            })?;
+
         let states = states
             .into_iter()
             .map(|(s, t, id)| (s, t_after_open_delim.clone().combine_chasles(t), id));
@@ -207,7 +223,7 @@ where
                         let trans = trans.combine_chasles(new_trans);
                         (state, trans, id)
                     })
-                    .map_err(|(span, expected)| Error::InvalidProducedAst { span, expected })
+                    .map_err(|(span, expected, cex)| CounterExamplePrefix::new(span, expected, cex))
             })
             .collect::<Result<_, _>>()?;
 
@@ -218,7 +234,7 @@ where
         &self,
         states: Set<(DynamicState<Span>, Id)>,
         stream: Cursor<Span>,
-    ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
+    ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, CounterExamplePrefix<Span>>
     where
         Id: Clone + Ord,
     {
@@ -227,9 +243,23 @@ where
             .map(|(s, id)| (s, (Transition::empty(), id)))
             .collect();
 
-        for tree in stream {
+        for (idx, tree) in stream.into_iter().enumerate() {
             states = self
-                .apply(states, |this, states| this.parse_single_tree(states, tree))?
+                .apply(states, |this, states| this.parse_single_tree(states, tree))
+                .map_err(|mut cex| {
+                    if idx < stream.len() {
+                        // SUBTLE: the pushdown automaton has a lookhead of 2
+                        // tokens. This means the error is always detected
+                        // "two tokens after" it actually occurs.
+                        //
+                        // However this is not an issue here. We found an
+                        // invalid expansion, and it will stay invalid no
+                        // matter what comes after it. Sweet!
+                        cex.push_stream(&stream[(idx + 1)..])
+                    }
+
+                    cex
+                })?
                 .into_iter()
                 .map(|(state, trans_, (trans, id))| (state, (trans.combine_chasles(trans_), id)))
                 .collect();
@@ -246,7 +276,7 @@ where
         stream: Cursor<Span>,
         sep: Option<&TokenTree<Span>>,
         quantifier: RepetitionQuantifier<Span>,
-    ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
+    ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, CounterExamplePrefix<Span>>
     where
         Id: Clone + Ord,
     {
@@ -270,7 +300,7 @@ where
         &self,
         states: Set<(DynamicState<Span>, Id)>,
         stream: Cursor<Span>,
-    ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
+    ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, CounterExamplePrefix<Span>>
     where
         Id: Clone + Ord,
     {
@@ -299,7 +329,7 @@ where
         states: Set<(DynamicState<Span>, Id)>,
         stream: Cursor<Span>,
         sep: Option<&TokenTree<Span>>,
-    ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
+    ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, CounterExamplePrefix<Span>>
     where
         Id: Clone + Ord,
     {
@@ -312,7 +342,7 @@ where
         stream: Cursor<Span>,
         sep: Option<&TokenTree<Span>>,
         mut first: bool,
-    ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
+    ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, CounterExamplePrefix<Span>>
     where
         Id: Clone + Ord,
     {
@@ -363,7 +393,7 @@ where
         states: Set<(DynamicState<Span>, Id)>,
         stream: Cursor<Span>,
         sep: Option<&TokenTree<Span>>,
-    ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
+    ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, CounterExamplePrefix<Span>>
     where
         Id: Clone + Ord,
     {
@@ -385,7 +415,7 @@ where
         states: Set<(DynamicState<Span>, Id)>,
         sep: Option<&TokenTree<Span>>,
         stream: Cursor<Span>,
-    ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
+    ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, CounterExamplePrefix<Span>>
     where
         Id: Clone + Ord,
     {
@@ -423,12 +453,13 @@ where
         &self,
         states: Set<(DynamicState<Span>, Id)>,
         mut f: F,
-    ) -> Result<Set<(DynamicState<Span>, Id_, Id)>, Error<Span>>
+    ) -> Result<Set<(DynamicState<Span>, Id_, Id)>, CounterExamplePrefix<Span>>
     where
         F: FnMut(
             &Self,
             Set<(DynamicState<Span>, usize)>,
-        ) -> Result<Set<(DynamicState<Span>, Id_, usize)>, Error<Span>>,
+        )
+            -> Result<Set<(DynamicState<Span>, Id_, usize)>, CounterExamplePrefix<Span>>,
         Id: Clone + Ord,
         Id_: Clone + Ord,
     {
@@ -448,11 +479,117 @@ where
     }
 }
 
+impl<Span> From<CounterExamplePrefix<Span>> for Error<Span> {
+    fn from(cex: CounterExamplePrefix<Span>) -> Error<Span> {
+        Error::InvalidProducedAst {
+            span: cex.exact_error_span,
+            expected: cex.expected,
+            counter_example: cex.prefix,
+        }
+    }
+}
+
 fn singleton<T>(t: T) -> Set<T>
 where
     T: Ord,
 {
     iter::once(t).collect()
+}
+
+#[derive(Clone, PartialEq)]
+struct CounterExamplePrefix<Span> {
+    exact_error_span: Span,
+    expected: Vec<TokenDescription>,
+    prefix: Vec<(TokenDescription, Span)>,
+}
+
+impl<Span> CounterExamplePrefix<Span>
+where
+    Span: Copy,
+{
+    fn new(
+        exact_error_span: Span,
+        expected: Vec<TokenDescription>,
+        prefix: Vec<(TokenDescription, Span)>,
+    ) -> CounterExamplePrefix<Span> {
+        CounterExamplePrefix {
+            exact_error_span,
+            expected,
+            prefix,
+        }
+    }
+
+    fn push(&mut self, descr: TokenDescription, span: Span) {
+        self.prefix.push((descr, span));
+    }
+
+    fn push_stream(&mut self, stream: &[TokenTree<Span>]) {
+        for tree in stream {
+            let span = tree.span;
+            match &tree.kind {
+                TokenTreeKind::Terminal(_, descr) => self.push(*descr, tree.span),
+                TokenTreeKind::Parenthesed(inner) => self.push_delimited_stream(
+                    TokenDescription::LParen,
+                    span,
+                    inner,
+                    TokenDescription::RParen,
+                    span,
+                ),
+
+                TokenTreeKind::CurlyBraced(inner) => self.push_delimited_stream(
+                    TokenDescription::LBrace,
+                    span,
+                    inner,
+                    TokenDescription::RBrace,
+                    span,
+                ),
+
+                TokenTreeKind::Bracketed(inner) => self.push_delimited_stream(
+                    TokenDescription::LBracket,
+                    span,
+                    inner,
+                    TokenDescription::RBracket,
+                    span,
+                ),
+
+                TokenTreeKind::Fragment(_f) => todo!(),
+
+                TokenTreeKind::Repetition {
+                    quantifier:
+                        RepetitionQuantifier {
+                            kind:
+                                RepetitionQuantifierKind::ZeroOrOne
+                                | RepetitionQuantifierKind::ZeroOrMore,
+                            ..
+                        },
+                    ..
+                } => {}
+
+                TokenTreeKind::Repetition {
+                    inner,
+                    quantifier:
+                        RepetitionQuantifier {
+                            kind: RepetitionQuantifierKind::OneOrMore,
+                            ..
+                        },
+                    ..
+                } => self.push_stream(inner),
+            }
+        }
+    }
+
+    fn push_delimited_stream(
+        &mut self,
+        open_descr: TokenDescription,
+        open_span: Span,
+        inner: &[TokenTree<Span>],
+        close_descr: TokenDescription,
+        close_span: Span,
+    ) {
+        self.push(open_descr, open_span);
+        self.push_stream(inner);
+        self.push(close_descr, close_span);
+    }
 }
 
 #[cfg(test)]
@@ -553,6 +690,112 @@ mod tests {
             ( #ident:ident ) => {
                 #( :: #ident )*
             }
+        }
+    }
+
+    macro_rules! assert_cex {
+        ( $test_name:ident { #[$kind:ident]( $( $matcher:tt )* ) => { $( $substitution:tt )* }; $expect:expr }) => {
+            #[test]
+            fn $test_name() {
+                let matcher: Vec<crate::TokenTree<_>> = quote! { $( $matcher )* };
+                let matcher = crate::matcher::TokenTree::from_generic(matcher).expect("Failed to generate `matcher::TokenTree`");
+                let bindings = crate::matcher::Matcher::from_generic(&matcher).expect("Failed to generate `matcher::Bindings`");
+
+                let subst = quote! { $( $substitution )* };
+                let subst = crate::substitution::TokenTree::from_generic(subst).expect("Failed to generate `substitution::TokenTree`");
+
+                let state = stringify!($kind).parse::<crate::InvocationContext>().expect("Failed to generate `FragmentKind`");
+                let state = state.to_state();
+
+                let e = check_arm(state, bindings, &subst).unwrap_err();
+
+                let left = match e {
+                    Error::InvalidProducedAst { counter_example, .. } => counter_example,
+                    _ => panic!("Unexpected error variant: {:?}", e),
+                };
+
+                let left = left.into_iter().map(|(tok, _)| tok).collect::<Vec<_>>();
+
+                let right = $expect;
+
+                right.assert_debug_eq(&left);
+            }
+        }
+    }
+
+    assert_cex! {
+        cex_simple_plusplus {
+            #[expr]
+            () => {
+                4 ++ 5
+            };
+            expect_test::expect![[r#"
+                [
+                    Literal,
+                    Plus,
+                    Plus,
+                    Literal,
+                ]
+            "#]]
+        }
+    }
+
+    assert_cex! {
+        cex_with_repetition {
+            #[expr]
+            () => {
+                #( 42 + )* + a
+            };
+            expect_test::expect![[r#"
+                [
+                    Literal,
+                    Plus,
+                    Literal,
+                    Plus,
+                    Plus,
+                    Ident,
+                ]
+            "#]]
+        }
+    }
+
+    assert_cex! {
+        // Performs an expansion check of the following macro:
+        //
+        // ```rust
+        // macro_rules! cex_with_fragment {
+        //     ($a:ident) => {
+        //         $( $a ++ )*
+        //     }
+        // }
+        // ```
+        //
+        // This macro expands may expand to invalid code, because Rust has no
+        // `++` operator. A possible expansion of this macro that exhibits this
+        // error is the following:
+        //
+        // ```
+        // a ++ b ++
+        // ```
+        cex_with_fragment {
+            #[expr]
+            (#a:ident) => {
+                #( #a ++ )*
+            };
+            expect_test::expect![[r#"
+                [
+                    Fragment(
+                        Ident,
+                    ),
+                    Plus,
+                    Plus,
+                    Fragment(
+                        Ident,
+                    ),
+                    Plus,
+                    Plus,
+                ]
+            "#]]
         }
     }
 }

--- a/expandable-impl/src/expansion.rs
+++ b/expandable-impl/src/expansion.rs
@@ -780,8 +780,6 @@ mod tests {
                 [
                     Literal,
                     Plus,
-                    Literal,
-                    Plus,
                     Plus,
                     Ident,
                 ]

--- a/expandable-impl/src/grammar.rs
+++ b/expandable-impl/src/grammar.rs
@@ -58,7 +58,8 @@ where
         self.eaten
             .len()
             .cmp(&other.eaten.len())
-            .reverse() // TODO: this rev seem to be necessary. Otherwise, ExpCtx::parse_stream starts with the longest traces first, which is bad.
+            .reverse() // TODO: this rev seem to be necessary. Otherwise, ExpCtx::parse_stream starts with the
+            // longest traces first, which is bad.
             .then_with(|| self.state.cmp(&other.state))
     }
 }

--- a/expandable-impl/src/grammar.rs
+++ b/expandable-impl/src/grammar.rs
@@ -487,7 +487,7 @@ mod tests {
         let tokens = [Literal, Plus, Literal, Plus];
 
         for token in tokens {
-            state_1 = state_1.accept(token, 0).unwrap().0;
+            state_1 = state_1.accept(token, ()).unwrap().0;
         }
 
         let mut state_2 = DynamicState::expr();
@@ -495,7 +495,7 @@ mod tests {
         let tokens = [Literal, Plus];
 
         for token in tokens {
-            state_2 = state_2.accept(token, 0).unwrap().0;
+            state_2 = state_2.accept(token, ()).unwrap().0;
         }
 
         assert!(state_1 < state_2);


### PR DESCRIPTION
This change affects only `expandable-impl` (ie: the backend). The frontend will be updated once I have a clear idea of how to leverage this.

While this is not documented, the algorithm favors _shorter_ traces, with as little repetition as possible. This may change in the future.