### PR TITLE
refactor: make the expansion check fully deterministic

### DIFF
--- a/expandable-impl/src/expansion.rs
+++ b/expandable-impl/src/expansion.rs
@@ -5,7 +5,6 @@ use std::{
     cell::RefCell,
     cmp::Ord,
     collections::{BTreeSet, HashMap},
-    hash::Hash,
     iter,
 };
 
@@ -91,7 +90,7 @@ where
         tree: &TokenTree<Span>,
     ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
     where
-        Id: Clone + Eq + Hash + Ord,
+        Id: Clone + Ord,
     {
         match &tree.kind {
             TokenTreeKind::Repetition {
@@ -122,7 +121,7 @@ where
         id: Id,
     ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
     where
-        Id: Clone + Eq + Hash + Ord,
+        Id: Clone + Ord,
     {
         match &tree.kind {
             TokenTreeKind::Terminal(_, descr) => state
@@ -185,7 +184,7 @@ where
         id: Id,
     ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
     where
-        Id: Clone + Eq + Hash + Ord,
+        Id: Clone + Ord,
     {
         // Parse open delimiter
         let (s_after_open_delim, t_after_open_delim) = initial_state
@@ -221,7 +220,7 @@ where
         stream: Cursor<Span>,
     ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
     where
-        Id: Clone + Eq + Hash + Ord,
+        Id: Clone + Ord,
     {
         let mut states: Set<(DynamicState<Span>, (Transition, Id))> = states
             .into_iter()
@@ -249,7 +248,7 @@ where
         quantifier: RepetitionQuantifier<Span>,
     ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
     where
-        Id: Clone + Eq + Hash + Ord,
+        Id: Clone + Ord,
     {
         match quantifier.kind {
             RepetitionQuantifierKind::ZeroOrOne => {
@@ -273,7 +272,7 @@ where
         stream: Cursor<Span>,
     ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
     where
-        Id: Clone + Eq + Hash + Ord,
+        Id: Clone + Ord,
     {
         let mut candidates = states
             .into_iter()
@@ -302,7 +301,7 @@ where
         sep: Option<&TokenTree<Span>>,
     ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
     where
-        Id: Clone + Eq + Hash + Ord,
+        Id: Clone + Ord,
     {
         self.parse_zero_or_more_repetitions_inner(states, stream, sep, true)
     }
@@ -315,7 +314,7 @@ where
         mut first: bool,
     ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
     where
-        Id: Clone + Eq + Hash + Ord,
+        Id: Clone + Ord,
     {
         // Values accumulated during the previous iterations.
         let mut outcomes = Set::new();
@@ -366,7 +365,7 @@ where
         sep: Option<&TokenTree<Span>>,
     ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
     where
-        Id: Clone + Eq + Hash + Ord,
+        Id: Clone + Ord,
     {
         let states = self
             .parse_single_repetition(states, None, stream)?
@@ -388,7 +387,7 @@ where
         stream: Cursor<Span>,
     ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
     where
-        Id: Eq + Hash + Clone + Ord,
+        Id: Clone + Ord,
     {
         let states = match sep {
             Some(sep) => {
@@ -430,8 +429,8 @@ where
             &Self,
             Set<(DynamicState<Span>, usize)>,
         ) -> Result<Set<(DynamicState<Span>, Id_, usize)>, Error<Span>>,
-        Id: Clone + Eq + Hash + Ord,
-        Id_: Clone + Eq + Hash + Ord,
+        Id: Clone + Ord,
+        Id_: Clone + Ord,
     {
         // Let's use usize as new id :)
         let (states, joint) = states
@@ -451,7 +450,7 @@ where
 
 fn singleton<T>(t: T) -> Set<T>
 where
-    T: Eq + Hash + Ord,
+    T: Ord,
 {
     iter::once(t).collect()
 }

--- a/expandable-impl/src/expansion.rs
+++ b/expandable-impl/src/expansion.rs
@@ -3,7 +3,8 @@
 
 use std::{
     cell::RefCell,
-    collections::{HashMap, HashSet},
+    cmp::Ord,
+    collections::{BTreeSet, HashMap},
     hash::Hash,
     iter,
 };
@@ -17,7 +18,7 @@ use crate::{
 };
 
 type Cursor<'ast, Span> = &'ast [TokenTree<Span>];
-type Set<T> = HashSet<T>;
+type Set<T> = BTreeSet<T>;
 
 pub(crate) fn check_arm<Span>(
     init_state: DynamicState<Span>,
@@ -90,7 +91,7 @@ where
         tree: &TokenTree<Span>,
     ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
     where
-        Id: Clone + Eq + Hash,
+        Id: Clone + Eq + Hash + Ord,
     {
         match &tree.kind {
             TokenTreeKind::Repetition {
@@ -121,7 +122,7 @@ where
         id: Id,
     ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
     where
-        Id: Clone + Eq + Hash,
+        Id: Clone + Eq + Hash + Ord,
     {
         match &tree.kind {
             TokenTreeKind::Terminal(_, descr) => state
@@ -184,7 +185,7 @@ where
         id: Id,
     ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
     where
-        Id: Clone + Eq + Hash,
+        Id: Clone + Eq + Hash + Ord,
     {
         // Parse open delimiter
         let (s_after_open_delim, t_after_open_delim) = initial_state
@@ -220,7 +221,7 @@ where
         stream: Cursor<Span>,
     ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
     where
-        Id: Clone + Eq + Hash,
+        Id: Clone + Eq + Hash + Ord,
     {
         let mut states: Set<(DynamicState<Span>, (Transition, Id))> = states
             .into_iter()
@@ -248,7 +249,7 @@ where
         quantifier: RepetitionQuantifier<Span>,
     ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
     where
-        Id: Clone + Eq + Hash,
+        Id: Clone + Eq + Hash + Ord,
     {
         match quantifier.kind {
             RepetitionQuantifierKind::ZeroOrOne => {
@@ -272,7 +273,7 @@ where
         stream: Cursor<Span>,
     ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
     where
-        Id: Clone + Eq + Hash,
+        Id: Clone + Eq + Hash + Ord,
     {
         let mut candidates = states
             .into_iter()
@@ -301,7 +302,7 @@ where
         sep: Option<&TokenTree<Span>>,
     ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
     where
-        Id: Clone + Eq + Hash,
+        Id: Clone + Eq + Hash + Ord,
     {
         self.parse_zero_or_more_repetitions_inner(states, stream, sep, true)
     }
@@ -314,7 +315,7 @@ where
         mut first: bool,
     ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
     where
-        Id: Clone + Eq + Hash,
+        Id: Clone + Eq + Hash + Ord,
     {
         // Values accumulated during the previous iterations.
         let mut outcomes = Set::new();
@@ -365,7 +366,7 @@ where
         sep: Option<&TokenTree<Span>>,
     ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
     where
-        Id: Clone + Eq + Hash,
+        Id: Clone + Eq + Hash + Ord,
     {
         let states = self
             .parse_single_repetition(states, None, stream)?
@@ -387,7 +388,7 @@ where
         stream: Cursor<Span>,
     ) -> Result<Set<(DynamicState<Span>, Transition, Id)>, Error<Span>>
     where
-        Id: Eq + Hash + Clone,
+        Id: Eq + Hash + Clone + Ord,
     {
         let states = match sep {
             Some(sep) => {
@@ -429,8 +430,8 @@ where
             &Self,
             Set<(DynamicState<Span>, usize)>,
         ) -> Result<Set<(DynamicState<Span>, Id_, usize)>, Error<Span>>,
-        Id: Clone + Eq + Hash,
-        Id_: Clone + Eq + Hash,
+        Id: Clone + Eq + Hash + Ord,
+        Id_: Clone + Eq + Hash + Ord,
     {
         // Let's use usize as new id :)
         let (states, joint) = states
@@ -450,7 +451,7 @@ where
 
 fn singleton<T>(t: T) -> Set<T>
 where
-    T: Eq + Hash,
+    T: Eq + Hash + Ord,
 {
     iter::once(t).collect()
 }

--- a/expandable-impl/src/grammar.rs
+++ b/expandable-impl/src/grammar.rs
@@ -2,6 +2,7 @@
 // the Rust language.
 
 use std::{
+    cmp::Ordering,
     hash::{Hash, Hasher},
     ptr,
 };
@@ -33,6 +34,24 @@ impl<Span> Eq for DynamicState<Span> {}
 impl<Span> Hash for DynamicState<Span> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.state.hash(state);
+    }
+}
+
+impl<Span> PartialOrd for DynamicState<Span>
+where
+    Span: Copy,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<Span> Ord for DynamicState<Span>
+where
+    Span: Copy,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.state.cmp(&other.state)
     }
 }
 

--- a/expandable-impl/src/grammar.rs
+++ b/expandable-impl/src/grammar.rs
@@ -15,23 +15,26 @@ use crate::{FragmentKind, Terminal};
 #[derive(Clone, Debug)]
 pub(crate) struct DynamicState<Span>
 where
-    Span: 'static,
+    Span: 'static + Copy,
 {
     pub(crate) state: RustParser<Span>,
 }
 
 impl<Span> PartialEq for DynamicState<Span>
 where
-    Span: 'static,
+    Span: 'static + Copy,
 {
     fn eq(&self, other: &Self) -> bool {
         ptr::eq(self, other) || self.state == other.state
     }
 }
 
-impl<Span> Eq for DynamicState<Span> {}
+impl<Span: 'static + Copy> Eq for DynamicState<Span> {}
 
-impl<Span> Hash for DynamicState<Span> {
+impl<Span> Hash for DynamicState<Span>
+where
+    Span: 'static + Copy,
+{
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.state.hash(state);
     }

--- a/rust-grammar-dpdfa/src/generated.rs
+++ b/rust-grammar-dpdfa/src/generated.rs
@@ -632,8 +632,6 @@ impl TransitionData {
         self.pushed.push(state);
     }
 }
-macro_rules ! call_now { ($ _input : expr $ (, $ arg : expr) * $ (,) ?) => { return Ok ({ Transition :: CallNow (& [$ (($ arg , stringify ! ($ arg))) , *]) }) } ; }
-macro_rules ! call_then { ($ input : expr $ (, $ arg : expr) * $ (,) ?) => { Ok ({ Transition :: CallThen (& [$ (($ arg , stringify ! ($ arg))) , *]) }) } ; }
 fn vis_6<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
     if input.peek_expect(LParen) {
         input.call_now(&[vis_5])

--- a/rust-grammar-dpdfa/src/generated.rs
+++ b/rust-grammar-dpdfa/src/generated.rs
@@ -158,20 +158,26 @@ impl TokenDescription {
     }
 }
 #[derive(Clone, Debug)]
-pub struct RustParser<Span: 'static> {
+pub struct RustParser<Span>
+where
+    Span: 'static + Copy,
+{
     buffer: TokenBuffer<Span>,
     stack: Vec<State<Span>>,
     tried: SmallVec<[TokenDescription; 10]>,
 }
-impl<Span> PartialEq for RustParser<Span> {
+impl<Span> PartialEq for RustParser<Span>
+where
+    Span: Copy + 'static,
+{
     fn eq(&self, other: &RustParser<Span>) -> bool {
         std::ptr::eq(self, other) || (self.buffer == other.buffer && self.stack == other.stack)
     }
 }
-impl<Span> Eq for RustParser<Span> {}
+impl<Span: Copy + 'static> Eq for RustParser<Span> {}
 impl<Span> Hash for RustParser<Span>
 where
-    Span: 'static,
+    Span: 'static + Copy,
 {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.buffer.hash(state);
@@ -432,56 +438,44 @@ enum ProgressError<Span> {
     ParsingError(Option<Span>, Vec<TokenDescription>),
 }
 #[derive(Clone, Debug)]
-enum TokenBuffer<Span> {
+enum TokenBuffer<Span>
+where
+    Span: Copy + 'static,
+{
     Empty([(TokenDescription, Span); 0]),
     Single([(TokenDescription, Span); 1]),
     Double([(TokenDescription, Span); 2]),
     Triple([(TokenDescription, Span); 3]),
 }
-impl<Span> Hash for TokenBuffer<Span> {
+impl<Span> Hash for TokenBuffer<Span>
+where
+    Span: Copy + 'static,
+{
     fn hash<H: Hasher>(&self, state: &mut H) {
         let discriminant = mem::discriminant(self);
         discriminant.hash(state);
-        match self {
-            TokenBuffer::Empty([]) => <[TokenDescription; 0] as Hash>::hash(&[], state),
-            TokenBuffer::Single([(a, _)]) => [a].hash(state),
-            TokenBuffer::Double([(a, _), (b, _)]) => [a, b].hash(state),
-            TokenBuffer::Triple([(a, _), (b, _), (c, _)]) => [a, b, c].hash(state),
-        }
+        self.tokens().for_each(|t| t.hash(state));
     }
 }
-impl<Span> PartialEq for TokenBuffer<Span> {
+impl<Span> PartialEq for TokenBuffer<Span>
+where
+    Span: Copy + 'static,
+{
     fn eq(&self, other: &TokenBuffer<Span>) -> bool {
         let self_tag = mem::discriminant(self);
         let arg1_tag = mem::discriminant(other);
-        self_tag == arg1_tag
-            && match (self, other) {
-                (TokenBuffer::Empty([]), TokenBuffer::Empty([])) => true,
-                (TokenBuffer::Single([(a, _)]), TokenBuffer::Single([(a_, _)])) => [a] == [a_],
-                (
-                    TokenBuffer::Double([(a, _), (b, _)]),
-                    TokenBuffer::Double([(a_, _), (b_, _)]),
-                ) => [a, b] == [a_, b_],
-                (
-                    TokenBuffer::Triple([(a, _), (b, _), (c, _)]),
-                    TokenBuffer::Triple([(a_, _), (b_, _), (c_, _)]),
-                ) => [a, b, c] == [a_, b_, c_],
-                _ => unreachable!(),
-            }
+        self_tag == arg1_tag && self.tokens().eq(other.tokens())
     }
 }
-impl<Span> Eq for TokenBuffer<Span> {}
+impl<Span: Copy> Eq for TokenBuffer<Span> {}
 impl<Span> Ord for TokenBuffer<Span>
 where
     Span: Copy + 'static,
 {
     fn cmp(&self, other: &TokenBuffer<Span>) -> Ordering {
-        self.len().cmp(&other.len()).then_with(|| {
-            self.as_slice()
-                .iter()
-                .map(|(t, _)| t)
-                .cmp(other.as_slice().iter().map(|(t, _)| t))
-        })
+        self.len()
+            .cmp(&other.len())
+            .then_with(|| self.tokens().cmp(other.tokens()))
     }
 }
 impl<Span> PartialOrd for TokenBuffer<Span>
@@ -494,7 +488,10 @@ where
 }
 type State<Span> = fn(&mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>>;
 #[derive(Clone, Copy, Debug, PartialEq)]
-enum Transition<Span: 'static> {
+enum Transition<Span>
+where
+    Span: Copy + 'static,
+{
     CallNow(&'static [State<Span>]),
     CallThen(&'static [State<Span>]),
 }
@@ -583,6 +580,10 @@ where
             | TokenBuffer::Double([(a, _), _])
             | TokenBuffer::Triple([(a, _), _, _]) => *a = descr,
         }
+    }
+
+    fn tokens(&self) -> impl Iterator<Item = TokenDescription> + '_ {
+        self.as_slice().iter().map(|(descr, _)| descr).copied()
     }
 
     fn as_slice(&self) -> &[(TokenDescription, Span)] {


### PR DESCRIPTION
We did not care about `expandable`'s deterministicness earlier because there our focus was on "is there an error and where". With #49, we also need to solve the question "how did we get here", which requires having a fixed order when checking a macro.

(Also I'm almost sure our testing is not optimal - otherwise we may have discovered this earlier)

Implementation-wise, this was fixed by switching from a `HashSet` to a `BTreeSet`. I believe this won't cause any performance issue because we will still have a low amount of states, resulting in a low amount of allocations anywhere. We are probably loosing big-O-wise, but we don't care about big-O because our numbers are smol enough.