### PR TITLE
feat: add missing [expandable::*] macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,15 @@ As a result, `expandable` must know what the macro expands to. To do so,
 multiple macros are available:
 - Macros that expand to expressions are checked by [`expandable::expr`],
 - Macros that expand to items are checked by [`expandable::item`],
-- TODO: pattern, statements, type.
+- Macros that expand to patterns are checked by [`expandable::pat`],
+- Macros that expand to statements are checked by [`expandable::stmt`],
+- Macros that expand to types are checked by [`expandable::ty`],
 
 [`expandable::expr`]: macro@expr
 [`expandable::item`]: macro@item
+[`expandable::pat`]: macro@pat
+[`expandable::stmt`]: macro@stmt
+[`expandable::ty`]: macro@ty
 ## What can it detect?
 
 This section briefly describes what the macros can detect and what they

--- a/expandable-impl/src/grammar.rs
+++ b/expandable-impl/src/grammar.rs
@@ -96,6 +96,20 @@ where
         }
     }
 
+    pub(crate) fn stmt() -> DynamicState<Span> {
+        DynamicState {
+            state: RustParser::stmt(),
+            eaten: Vec::new(),
+        }
+    }
+
+    pub(crate) fn ty() -> DynamicState<Span> {
+        DynamicState {
+            state: RustParser::ty(),
+            eaten: Vec::new(),
+        }
+    }
+
     pub(crate) fn accept_fragment(
         self,
         fragment: FragmentKind,

--- a/expandable-impl/src/lib.rs
+++ b/expandable-impl/src/lib.rs
@@ -486,6 +486,10 @@ pub enum InvocationContext {
     Item,
     /// The macro expands to a pattern.
     Pat,
+    /// The macro expands to any number of statement.
+    Stmt,
+    /// The macro expands to a type.
+    Ty,
 }
 
 impl InvocationContext {
@@ -497,6 +501,8 @@ impl InvocationContext {
             InvocationContext::Expr => DynamicState::expr(),
             InvocationContext::Item => DynamicState::item(),
             InvocationContext::Pat => DynamicState::pat(),
+            InvocationContext::Stmt => DynamicState::stmt(),
+            InvocationContext::Ty => DynamicState::ty(),
         }
     }
 }

--- a/rust-grammar-dpdfa/grammar.rs
+++ b/rust-grammar-dpdfa/grammar.rs
@@ -62,92 +62,98 @@ fn fn_item() {
     block();
 }
 
+pub fn stmt() {
+    stmt_tail();
+}
+
 fn block() {
     bump(LBrace);
-
     stmt_tail();
+    bump(RBrace);
 }
 
 // Parses stmts until the end of the block
 fn stmt_tail() {
-    if peek(RBrace) {
-        bump(RBrace);
-    } else if peek(Semicolon) {
-        bump(Semicolon);
-        stmt_tail();
-    } else if peek(Let) {
-        bump(Let);
-        pat();
-        if peek(Colon) {
-            bump(Colon);
-            ty();
-        }
-        bump(Equals);
-        expr();
+    if peek() {
+        if peek(RBrace) {
+            // return
+        } else if peek(Semicolon) {
+            bump(Semicolon);
+            stmt_tail();
+        } else if peek(Let) {
+            bump(Let);
+            pat();
+            if peek(Colon) {
+                bump(Colon);
+                ty();
+            }
+            bump(Equals);
+            expr();
 
-        // Let statements are always ended by semicolons.
-        bump(Semicolon);
+            // Let statements are always ended by semicolons.
+            bump(Semicolon);
 
-        stmt_tail();
-    } else if peek(ColonColon)
-        || peek(Ident)
-        || peek(FragmentIdent)
-        || peek(Super)
-        || peek(Self_)
-        || peek(Crate)
-        || peek(FragmentPath)
-    {
-        // Potential macro/struct expression
-        expr_path();
-        if peek(Not) {
-            if peek2(LBrace) {
-                macro_call_tail();
+            stmt_tail();
+        } else if peek(ColonColon)
+            || peek(Ident)
+            || peek(FragmentIdent)
+            || peek(Super)
+            || peek(Self_)
+            || peek(Crate)
+            || peek(FragmentPath)
+        {
+            // Potential macro/struct expression
+            expr_path();
+            if peek(Not) {
+                if peek2(LBrace) {
+                    macro_call_tail();
 
-                // TODO: make sure this is the FIRST set of macro_call_tail
-                if peek(Plus)
-                    || peek(Minus)
-                    || peek(Star)
-                    || peek(Slash)
-                    || peek(Percent)
-                    || peek(And)
-                    || peek(Or)
-                    || peek(Caret)
-                    || peek(Shl)
-                    || peek(Shr)
-                    || peek(EqualsEquals)
-                    || peek(NotEquals)
-                    || peek(GreaterThan)
-                    || peek(LessThan)
-                    || peek(GreaterThanEquals)
-                    || peek(LessThanEquals)
-                    || peek(OrOr)
-                    || peek(AndAnd)
-                    || peek(DotDot)
-                    || peek(DotDotEquals)
-                    || peek(LParen)
-                    || peek(LBracket)
-                    || peek(Dot)
-                {
+                    // TODO: make sure this is the FIRST set of macro_call_tail
+                    if peek(Plus)
+                        || peek(Minus)
+                        || peek(Star)
+                        || peek(Slash)
+                        || peek(Percent)
+                        || peek(And)
+                        || peek(Or)
+                        || peek(Caret)
+                        || peek(Shl)
+                        || peek(Shr)
+                        || peek(EqualsEquals)
+                        || peek(NotEquals)
+                        || peek(GreaterThan)
+                        || peek(LessThan)
+                        || peek(GreaterThanEquals)
+                        || peek(LessThanEquals)
+                        || peek(OrOr)
+                        || peek(AndAnd)
+                        || peek(DotDot)
+                        || peek(DotDotEquals)
+                        || peek(LParen)
+                        || peek(LBracket)
+                        || peek(Dot)
+                    {
+                        expr_after_atom();
+                        stmt_end_semi();
+                    } else {
+                        stmt_end_nosemi();
+                    }
+                } else {
+                    macro_call_tail();
                     expr_after_atom();
                     stmt_end_semi();
-                } else {
-                    stmt_end_nosemi();
                 }
             } else {
-                macro_call_tail();
+                // Not a macro - that was just an expression.
+                //
+                // TODO: add struct creation here.
                 expr_after_atom();
                 stmt_end_semi();
             }
         } else {
-            // Not a macro - that was just an expression.
-            //
-            // TODO: add struct creation here.
-            expr_after_atom();
+            expr();
             stmt_end_semi();
         }
-    } else {
-        expr();
-        stmt_end_semi();
     }
 }
 
@@ -156,7 +162,7 @@ fn stmt_end_semi() {
         bump(Semicolon);
         stmt_tail();
     } else if peek(RBrace) {
-        bump(RBrace);
+        // return
     } else {
         error();
     }
@@ -164,7 +170,7 @@ fn stmt_end_semi() {
 
 fn stmt_end_nosemi() {
     if peek(RBrace) {
-        bump(RBrace);
+        // return
     } else {
         stmt_tail();
     }

--- a/rust-grammar-dpdfa/src/generated.rs
+++ b/rust-grammar-dpdfa/src/generated.rs
@@ -226,6 +226,14 @@ where
         }
     }
 
+    pub fn stmt() -> RustParser<Span> {
+        RustParser {
+            buffer: TokenBuffer::Empty([]),
+            stack: vec![stmt],
+            tried: SmallVec::new(),
+        }
+    }
+
     pub fn ty() -> RustParser<Span> {
         RustParser {
             buffer: TokenBuffer::Empty([]),
@@ -816,118 +824,134 @@ fn fn_item_15<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Spa
 fn fn_item<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
     input.call_now(&[fn_item_15])
 }
-fn block_0<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+fn stmt_0<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
     input.call_now(&[stmt_tail])
 }
-fn block_1<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
-    input.bump_expect(LBrace, &[])
+fn stmt_1<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[stmt_0])
 }
-fn block_2<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[block_0, block_1])
+fn stmt<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[stmt_1])
 }
-fn block<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[block_2])
-}
-fn stmt_tail_42<Span: Copy>(
-    input: &mut RustParser<Span>,
-) -> Result<Transition<Span>, Option<Span>> {
-    if input.peek_expect(RBrace) {
-        input.call_now(&[stmt_tail_1])
-    } else {
-        input.call_now(&[stmt_tail_41])
-    }
-}
-fn stmt_tail_0<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+fn block_0<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
     input.bump_expect(RBrace, &[])
 }
-fn stmt_tail_1<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[stmt_tail_0])
-}
-fn stmt_tail_41<Span: Copy>(
-    input: &mut RustParser<Span>,
-) -> Result<Transition<Span>, Option<Span>> {
-    if input.peek_expect(Semicolon) {
-        input.call_now(&[stmt_tail_4])
-    } else {
-        input.call_now(&[stmt_tail_40])
-    }
-}
-fn stmt_tail_2<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+fn block_1<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
     input.call_now(&[stmt_tail])
 }
-fn stmt_tail_3<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
-    input.bump_expect(Semicolon, &[])
+fn block_2<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+    input.bump_expect(LBrace, &[])
 }
-fn stmt_tail_4<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[stmt_tail_2, stmt_tail_3])
+fn block_3<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[block_0, block_1, block_2])
 }
-fn stmt_tail_40<Span: Copy>(
+fn block<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[block_3])
+}
+fn stmt_tail_43<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    if input.peek_expect(Let) {
-        input.call_now(&[stmt_tail_15])
-    } else {
-        input.call_now(&[stmt_tail_39])
-    }
-}
-fn stmt_tail_5<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[stmt_tail])
-}
-fn stmt_tail_6<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
-    input.bump_expect(Semicolon, &[])
-}
-fn stmt_tail_7<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[expr])
-}
-fn stmt_tail_8<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
-    input.bump_expect(Equals, &[])
-}
-fn stmt_tail_12<Span: Copy>(
-    input: &mut RustParser<Span>,
-) -> Result<Transition<Span>, Option<Span>> {
-    if input.peek_expect(Colon) {
-        input.call_now(&[stmt_tail_11])
+    if input.peek_noexpect() {
+        input.call_now(&[stmt_tail_42])
     } else {
         input.call_now(&[])
     }
 }
-fn stmt_tail_9<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[ty])
-}
-fn stmt_tail_10<Span: Copy>(
+fn stmt_tail_41<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.bump_expect(Colon, &[])
+    if input.peek_expect(RBrace) {
+        input.call_now(&[stmt_tail_0])
+    } else {
+        input.call_now(&[stmt_tail_40])
+    }
+}
+fn stmt_tail_0<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[])
+}
+fn stmt_tail_40<Span: Copy>(
+    input: &mut RustParser<Span>,
+) -> Result<Transition<Span>, Option<Span>> {
+    if input.peek_expect(Semicolon) {
+        input.call_now(&[stmt_tail_3])
+    } else {
+        input.call_now(&[stmt_tail_39])
+    }
+}
+fn stmt_tail_1<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[stmt_tail])
+}
+fn stmt_tail_2<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+    input.bump_expect(Semicolon, &[])
+}
+fn stmt_tail_3<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[stmt_tail_1, stmt_tail_2])
+}
+fn stmt_tail_39<Span: Copy>(
+    input: &mut RustParser<Span>,
+) -> Result<Transition<Span>, Option<Span>> {
+    if input.peek_expect(Let) {
+        input.call_now(&[stmt_tail_14])
+    } else {
+        input.call_now(&[stmt_tail_38])
+    }
+}
+fn stmt_tail_4<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[stmt_tail])
+}
+fn stmt_tail_5<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+    input.bump_expect(Semicolon, &[])
+}
+fn stmt_tail_6<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[expr])
+}
+fn stmt_tail_7<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+    input.bump_expect(Equals, &[])
 }
 fn stmt_tail_11<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[stmt_tail_9, stmt_tail_10])
+    if input.peek_expect(Colon) {
+        input.call_now(&[stmt_tail_10])
+    } else {
+        input.call_now(&[])
+    }
 }
-fn stmt_tail_13<Span: Copy>(
+fn stmt_tail_8<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[ty])
+}
+fn stmt_tail_9<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+    input.bump_expect(Colon, &[])
+}
+fn stmt_tail_10<Span: Copy>(
+    input: &mut RustParser<Span>,
+) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[stmt_tail_8, stmt_tail_9])
+}
+fn stmt_tail_12<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
     input.call_now(&[pat])
 }
-fn stmt_tail_14<Span: Copy>(
+fn stmt_tail_13<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
     input.bump_expect(Let, &[])
 }
-fn stmt_tail_15<Span: Copy>(
+fn stmt_tail_14<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
     input.call_now(&[
+        stmt_tail_4,
         stmt_tail_5,
         stmt_tail_6,
         stmt_tail_7,
-        stmt_tail_8,
+        stmt_tail_11,
         stmt_tail_12,
         stmt_tail_13,
-        stmt_tail_14,
     ])
 }
-fn stmt_tail_39<Span: Copy>(
+fn stmt_tail_38<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
     if input.peek_expect(ColonColon)
@@ -938,30 +962,30 @@ fn stmt_tail_39<Span: Copy>(
         || input.peek_expect(Crate)
         || input.peek_expect(FragmentPath)
     {
-        input.call_now(&[stmt_tail_35])
+        input.call_now(&[stmt_tail_34])
     } else {
-        input.call_now(&[stmt_tail_38])
+        input.call_now(&[stmt_tail_37])
     }
 }
-fn stmt_tail_33<Span: Copy>(
+fn stmt_tail_32<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
     if input.peek_expect(Not) {
-        input.call_now(&[stmt_tail_29])
+        input.call_now(&[stmt_tail_28])
     } else {
-        input.call_now(&[stmt_tail_32])
+        input.call_now(&[stmt_tail_31])
     }
 }
-fn stmt_tail_28<Span: Copy>(
+fn stmt_tail_27<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
     if input.peek2_expect(LBrace) {
-        input.call_now(&[stmt_tail_23])
+        input.call_now(&[stmt_tail_22])
     } else {
-        input.call_now(&[stmt_tail_27])
+        input.call_now(&[stmt_tail_26])
     }
 }
-fn stmt_tail_21<Span: Copy>(
+fn stmt_tail_20<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
     if input.peek_expect(Plus)
@@ -988,126 +1012,131 @@ fn stmt_tail_21<Span: Copy>(
         || input.peek_expect(LBracket)
         || input.peek_expect(Dot)
     {
-        input.call_now(&[stmt_tail_18])
+        input.call_now(&[stmt_tail_17])
     } else {
-        input.call_now(&[stmt_tail_20])
+        input.call_now(&[stmt_tail_19])
     }
+}
+fn stmt_tail_15<Span: Copy>(
+    input: &mut RustParser<Span>,
+) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[stmt_end_semi])
 }
 fn stmt_tail_16<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[stmt_end_semi])
+    input.call_now(&[expr_after_atom])
 }
 fn stmt_tail_17<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[expr_after_atom])
+    input.call_now(&[stmt_tail_15, stmt_tail_16])
 }
 fn stmt_tail_18<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[stmt_tail_16, stmt_tail_17])
+    input.call_now(&[stmt_end_nosemi])
 }
 fn stmt_tail_19<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[stmt_end_nosemi])
+    input.call_now(&[stmt_tail_18])
 }
-fn stmt_tail_20<Span: Copy>(
+fn stmt_tail_21<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[stmt_tail_19])
+    input.call_now(&[macro_call_tail])
 }
 fn stmt_tail_22<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[macro_call_tail])
+    input.call_now(&[stmt_tail_20, stmt_tail_21])
 }
 fn stmt_tail_23<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[stmt_tail_21, stmt_tail_22])
+    input.call_now(&[stmt_end_semi])
 }
 fn stmt_tail_24<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[stmt_end_semi])
+    input.call_now(&[expr_after_atom])
 }
 fn stmt_tail_25<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[expr_after_atom])
+    input.call_now(&[macro_call_tail])
 }
 fn stmt_tail_26<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[macro_call_tail])
+    input.call_now(&[stmt_tail_23, stmt_tail_24, stmt_tail_25])
 }
-fn stmt_tail_27<Span: Copy>(
+fn stmt_tail_28<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[stmt_tail_24, stmt_tail_25, stmt_tail_26])
+    input.call_now(&[stmt_tail_27])
 }
 fn stmt_tail_29<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[stmt_tail_28])
+    input.call_now(&[stmt_end_semi])
 }
 fn stmt_tail_30<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[stmt_end_semi])
+    input.call_now(&[expr_after_atom])
 }
 fn stmt_tail_31<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[expr_after_atom])
+    input.call_now(&[stmt_tail_29, stmt_tail_30])
 }
-fn stmt_tail_32<Span: Copy>(
-    input: &mut RustParser<Span>,
-) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[stmt_tail_30, stmt_tail_31])
-}
-fn stmt_tail_34<Span: Copy>(
+fn stmt_tail_33<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
     input.call_now(&[expr_path])
 }
-fn stmt_tail_35<Span: Copy>(
+fn stmt_tail_34<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[stmt_tail_33, stmt_tail_34])
+    input.call_now(&[stmt_tail_32, stmt_tail_33])
 }
-fn stmt_tail_36<Span: Copy>(
+fn stmt_tail_35<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
     input.call_now(&[stmt_end_semi])
 }
-fn stmt_tail_37<Span: Copy>(
+fn stmt_tail_36<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
     input.call_now(&[expr])
 }
-fn stmt_tail_38<Span: Copy>(
+fn stmt_tail_37<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[stmt_tail_36, stmt_tail_37])
+    input.call_now(&[stmt_tail_35, stmt_tail_36])
 }
-fn stmt_tail_43<Span: Copy>(
+fn stmt_tail_42<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[stmt_tail_42])
+    input.call_now(&[stmt_tail_41])
 }
-fn stmt_tail<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+fn stmt_tail_44<Span: Copy>(
+    input: &mut RustParser<Span>,
+) -> Result<Transition<Span>, Option<Span>> {
     input.call_now(&[stmt_tail_43])
 }
-fn stmt_end_semi_8<Span: Copy>(
+fn stmt_tail<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[stmt_tail_44])
+}
+fn stmt_end_semi_7<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
     if input.peek_expect(Semicolon) {
         input.call_now(&[stmt_end_semi_2])
     } else {
-        input.call_now(&[stmt_end_semi_7])
+        input.call_now(&[stmt_end_semi_6])
     }
 }
 fn stmt_end_semi_0<Span: Copy>(
@@ -1125,83 +1154,73 @@ fn stmt_end_semi_2<Span: Copy>(
 ) -> Result<Transition<Span>, Option<Span>> {
     input.call_now(&[stmt_end_semi_0, stmt_end_semi_1])
 }
-fn stmt_end_semi_7<Span: Copy>(
+fn stmt_end_semi_6<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
     if input.peek_expect(RBrace) {
-        input.call_now(&[stmt_end_semi_4])
+        input.call_now(&[stmt_end_semi_3])
     } else {
-        input.call_now(&[stmt_end_semi_6])
+        input.call_now(&[stmt_end_semi_5])
     }
 }
 fn stmt_end_semi_3<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.bump_expect(RBrace, &[])
+    input.call_now(&[])
 }
 fn stmt_end_semi_4<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[stmt_end_semi_3])
+    input.error()
 }
 fn stmt_end_semi_5<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.error()
+    input.call_now(&[stmt_end_semi_4])
 }
-fn stmt_end_semi_6<Span: Copy>(
+fn stmt_end_semi_8<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[stmt_end_semi_5])
-}
-fn stmt_end_semi_9<Span: Copy>(
-    input: &mut RustParser<Span>,
-) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[stmt_end_semi_8])
+    input.call_now(&[stmt_end_semi_7])
 }
 fn stmt_end_semi<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[stmt_end_semi_9])
+    input.call_now(&[stmt_end_semi_8])
 }
-fn stmt_end_nosemi_4<Span: Copy>(
+fn stmt_end_nosemi_3<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
     if input.peek_expect(RBrace) {
-        input.call_now(&[stmt_end_nosemi_1])
+        input.call_now(&[stmt_end_nosemi_0])
     } else {
-        input.call_now(&[stmt_end_nosemi_3])
+        input.call_now(&[stmt_end_nosemi_2])
     }
 }
 fn stmt_end_nosemi_0<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.bump_expect(RBrace, &[])
+    input.call_now(&[])
 }
 fn stmt_end_nosemi_1<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[stmt_end_nosemi_0])
+    input.call_now(&[stmt_tail])
 }
 fn stmt_end_nosemi_2<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[stmt_tail])
+    input.call_now(&[stmt_end_nosemi_1])
 }
-fn stmt_end_nosemi_3<Span: Copy>(
+fn stmt_end_nosemi_4<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[stmt_end_nosemi_2])
-}
-fn stmt_end_nosemi_5<Span: Copy>(
-    input: &mut RustParser<Span>,
-) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[stmt_end_nosemi_4])
+    input.call_now(&[stmt_end_nosemi_3])
 }
 fn stmt_end_nosemi<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[stmt_end_nosemi_5])
+    input.call_now(&[stmt_end_nosemi_4])
 }
 fn ty_10<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
     if input.peek_expect(FragmentTy) {

--- a/rust-grammar-dpdfa/src/tests.rs
+++ b/rust-grammar-dpdfa/src/tests.rs
@@ -33,8 +33,8 @@ macro_rules! check_parse {
             match parser.finish() {
                 Ok(()) => {},
 
-                Err(_) => {
-                    panic!("Failed to finish parsing");
+                Err(e) => {
+                    panic!("Failed to finish parsing: {:?}", e);
                 }
             }
         }
@@ -277,6 +277,15 @@ check_parse! {
                 macro_call! {}
                 42
             }
+        }
+    }
+}
+
+check_parse! {
+    fn stmt_entry_point() {
+        stmt,
+        {
+            let _ = 42;
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,10 +38,15 @@
 //! multiple macros are available:
 //! - Macros that expand to expressions are checked by [`expandable::expr`],
 //! - Macros that expand to items are checked by [`expandable::item`],
-//! - TODO: pattern, statements, type.
+//! - Macros that expand to patterns are checked by [`expandable::pat`],
+//! - Macros that expand to statements are checked by [`expandable::stmt`],
+//! - Macros that expand to types are checked by [`expandable::ty`],
 //!
 //! [`expandable::expr`]: macro@expr
 //! [`expandable::item`]: macro@item
+//! [`expandable::pat`]: macro@pat
+//! [`expandable::stmt`]: macro@stmt
+//! [`expandable::ty`]: macro@ty
 #![doc = include_str!("../doc/02-what-can-it-detect.md")]
 //!
 #![doc = include_str!("../doc/03-opinionated.md")]
@@ -79,6 +84,8 @@ macro_rules! attribute_macro {
 attribute_macro!(expr => Expr);
 attribute_macro!(item => Item);
 attribute_macro!(pat => Pat);
+attribute_macro!(stmt => Stmt);
+attribute_macro!(ty => Ty);
 
 fn expandable_inner(ctx: expandable_impl::InvocationContext, item: TokenStream1) -> TokenStream1 {
     let mut item_ = item.clone();

--- a/tests/ui/pass/all-entry-points.rs
+++ b/tests/ui/pass/all-entry-points.rs
@@ -1,0 +1,38 @@
+#![allow(unused)]
+
+#[expandable::expr]
+macro_rules! e {
+    () => {
+        42
+    };
+}
+
+#[expandable::item]
+macro_rules! f {
+    () => {
+        fn f() {}
+    };
+}
+
+#[expandable::pat]
+macro_rules! f {
+    () => {
+        _
+    };
+}
+
+#[expandable::stmt]
+macro_rules! f {
+    () => {
+        let _ = 42;
+    };
+}
+
+#[expandable::ty]
+macro_rules! f {
+    () => {
+        Foo<Bar>
+    };
+}
+
+fn main() {}


### PR DESCRIPTION
Added macros:

- `#[expandable::stmt]` (any number of statement)
- `#[expandable::ty]` (a type)