### PR TITLE
feat: allow grammar-gen functions to return atoms

### DIFF
--- a/expandable-impl/src/expansion.rs
+++ b/expandable-impl/src/expansion.rs
@@ -560,7 +560,7 @@ where
                 ),
 
                 TokenTreeKind::Fragment(name) => {
-                    self.push(TokenDescription::Fragment(tbl[name].kind.clone()), span)
+                    self.push(TokenDescription::Fragment(tbl[name].kind), span);
                 }
 
                 TokenTreeKind::Repetition {

--- a/grammar-gen/src/codegen.rs
+++ b/grammar-gen/src/codegen.rs
@@ -36,7 +36,7 @@ fn check_all_functions_are_defined(productions: &[Production]) {
 
     for prod in productions {
         match &prod.kind {
-            ProductionKind::Bump { descr: _, then } | ProductionKind::CallNow { then } => {
+            ProductionKind::Bump { descr: _, then } | ProductionKind::CallNow { then, .. } => {
                 check_all_defined(then)
             }
 
@@ -50,6 +50,8 @@ fn check_all_functions_are_defined(productions: &[Production]) {
                 check_all_defined(cons);
                 check_all_defined(alt);
             }
+
+            ProductionKind::Ret { .. } => {}
         }
     }
 }

--- a/grammar-gen/src/codegen/rt.rs
+++ b/grammar-gen/src/codegen/rt.rs
@@ -254,14 +254,6 @@ pub(crate) fn runtime_base(entry_points: impl IntoIterator<Item = Ident>) -> Tok
             pub buf_size: usize,
             // TODO: wrap this in an opaque type.
             pub pushed: Vec<TypeErasedState>,
-            pub retval: RetVal,
-        }
-
-        #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-        pub enum RetVal {
-            Unchanged,
-            Set(&'static str),
-            Unset,
         }
 
         #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -292,7 +284,6 @@ pub(crate) fn runtime_base(entry_points: impl IntoIterator<Item = Ident>) -> Tok
                             popped: 0,
                             buf_size,
                             pushed: vec![],
-                            retval: RetVal::Unchanged,
                         });
                     },
 
@@ -699,7 +690,6 @@ pub(crate) fn runtime_base(entry_points: impl IntoIterator<Item = Ident>) -> Tok
                     popped: 0,
                     buf_size: 0,
                     pushed: vec![],
-                    retval: RetVal::Unchanged,
                 }
             }
 
@@ -712,11 +702,6 @@ pub(crate) fn runtime_base(entry_points: impl IntoIterator<Item = Ident>) -> Tok
                     self.log_push(pushed);
                 }
 
-                self.retval = match (self.retval, other.retval) {
-                    (anything, RetVal::Unchanged) => anything,
-                    (_, anything) => anything,
-                };
-
                 self
             }
 
@@ -725,7 +710,6 @@ pub(crate) fn runtime_base(entry_points: impl IntoIterator<Item = Ident>) -> Tok
                     popped: 0,
                     buf_size: 3,
                     pushed: vec![],
-                    retval: RetVal::Unchanged,
                 }
             }
 
@@ -737,14 +721,6 @@ pub(crate) fn runtime_base(entry_points: impl IntoIterator<Item = Ident>) -> Tok
 
             fn log_push(&mut self, state: TypeErasedState) {
                 self.pushed.push(state);
-            }
-
-            fn log_set_ret(&mut self, val: &'static str) {
-                self.retval = RetVal::Set(val);
-            }
-
-            fn log_clear_ret(&mut self) {
-                self.retval = RetVal::Unset;
             }
         }
     }

--- a/grammar-gen/src/mir.rs
+++ b/grammar-gen/src/mir.rs
@@ -138,7 +138,7 @@ impl Production {
                     .iter()
                     .map(|b_e| {
                         (
-                            b_e.builtin.clone(),
+                            b_e.builtin,
                             b_e.predicate.as_ref().map(|pred| pred.ident.clone()),
                         )
                     })

--- a/rust-grammar-dpdfa/src/generated.rs
+++ b/rust-grammar-dpdfa/src/generated.rs
@@ -211,13 +211,6 @@ pub struct TransitionData {
     pub popped: usize,
     pub buf_size: usize,
     pub pushed: Vec<TypeErasedState>,
-    pub retval: RetVal,
-}
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub enum RetVal {
-    Unchanged,
-    Set(&'static str),
-    Unset,
 }
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct TypeErasedState {
@@ -284,7 +277,6 @@ where
                     popped: 0,
                     buf_size,
                     pushed: vec![],
-                    retval: RetVal::Unchanged,
                 });
             }
             2 => {
@@ -637,7 +629,6 @@ impl TransitionData {
             popped: 0,
             buf_size: 0,
             pushed: vec![],
-            retval: RetVal::Unchanged,
         }
     }
 
@@ -648,10 +639,6 @@ impl TransitionData {
         for pushed in other.pushed {
             self.log_push(pushed);
         }
-        self.retval = match (self.retval, other.retval) {
-            (anything, RetVal::Unchanged) => anything,
-            (_, anything) => anything,
-        };
         self
     }
 
@@ -660,7 +647,6 @@ impl TransitionData {
             popped: 0,
             buf_size: 3,
             pushed: vec![],
-            retval: RetVal::Unchanged,
         }
     }
 
@@ -672,14 +658,6 @@ impl TransitionData {
 
     fn log_push(&mut self, state: TypeErasedState) {
         self.pushed.push(state);
-    }
-
-    fn log_set_ret(&mut self, val: &'static str) {
-        self.retval = RetVal::Set(val);
-    }
-
-    fn log_clear_ret(&mut self) {
-        self.retval = RetVal::Unset;
     }
 }
 fn vis_12<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {


### PR DESCRIPTION
Will be _very_ helpful for #29.

The return atom system allows parsing functions to return atoms to their caller. The returned atom is available only until the next token is consumed, and may be overwritten by subsequent calls.

The return value is set by calling `return atom;` and can be tested by calling the `returned(atom)` predicate.

In addition, the counterexample generator has been tweaked so that it does not panic when generating a counterexample that contains fragments.