### PR TITLE
feat: match expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ macro_rules! js_concat {
 
 This emits the following error [^error-message]:
 ```none
-error: Potentially invalid expansion. Expected an expression, an identifier, `::`, `<`, `Self`, `break` or 12 others.
+error: Potentially invalid expansion. Expected an expression, an identifier, `::`, `<`, `Self`, `break` or 13 others.
  --> tests/ui/fail/js_concat.rs:5:16
   |
 5 |         $left ++ $right

--- a/rust-grammar-dpdfa/grammar.rs
+++ b/rust-grammar-dpdfa/grammar.rs
@@ -794,6 +794,8 @@ fn expr_atom() {
         expr_while();
     } else if peek(For) {
         expr_for();
+    } else if peek(Match) {
+        expr_match();
     } else {
         error();
     }
@@ -1148,6 +1150,41 @@ fn expr_for() {
     // TODO: we must not allow struct expressions here
     expr();
     block();
+}
+
+fn expr_match() {
+    bump(Match);
+    // TODO(scrabsha): should be expr(no struct expression)
+    expr();
+
+    bump(LBrace);
+    match_arms();
+    bump(RBrace);
+}
+
+fn match_arms() {
+    if peek(RBrace) {
+        // return
+    } else {
+        match_arm();
+        match_arms();
+    }
+}
+
+fn match_arm() {
+    pat();
+
+    if peek(If) {
+        bump(If);
+        expr();
+    }
+
+    bump(FatArrow);
+
+    expr();
+    // TODO: commas are not mandatory if the expression is an
+    // ExpressionWithBlock.
+    bump(Comma);
 }
 
 fn macro_call_tail() {

--- a/rust-grammar-dpdfa/src/generated.rs
+++ b/rust-grammar-dpdfa/src/generated.rs
@@ -3891,13 +3891,13 @@ fn expr_after_atom<Span: Copy>(
 ) -> Result<Transition<Span>, Option<Span>> {
     input.call_now(&[expr_after_atom_31])
 }
-fn expr_atom_34<Span: Copy>(
+fn expr_atom_37<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
     if input.peek_expect(Return) || input.peek_expect(Break) {
         input.call_now(&[expr_atom_1])
     } else {
-        input.call_now(&[expr_atom_33])
+        input.call_now(&[expr_atom_36])
     }
 }
 fn expr_atom_0<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
@@ -3906,7 +3906,7 @@ fn expr_atom_0<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Sp
 fn expr_atom_1<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
     input.call_now(&[expr_atom_0])
 }
-fn expr_atom_33<Span: Copy>(
+fn expr_atom_36<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
     if input.peek_expect(Ident)
@@ -3920,7 +3920,7 @@ fn expr_atom_33<Span: Copy>(
     {
         input.call_now(&[expr_atom_6])
     } else {
-        input.call_now(&[expr_atom_32])
+        input.call_now(&[expr_atom_35])
     }
 }
 fn expr_atom_4<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
@@ -3942,7 +3942,7 @@ fn expr_atom_5<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Sp
 fn expr_atom_6<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
     input.call_now(&[expr_atom_4, expr_atom_5])
 }
-fn expr_atom_32<Span: Copy>(
+fn expr_atom_35<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
     if input.peek_expect(FragmentExpr)
@@ -3951,7 +3951,7 @@ fn expr_atom_32<Span: Copy>(
     {
         input.call_now(&[expr_atom_8])
     } else {
-        input.call_now(&[expr_atom_31])
+        input.call_now(&[expr_atom_34])
     }
 }
 fn expr_atom_7<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
@@ -3960,13 +3960,13 @@ fn expr_atom_7<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Sp
 fn expr_atom_8<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
     input.call_now(&[expr_atom_7])
 }
-fn expr_atom_31<Span: Copy>(
+fn expr_atom_34<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
     if input.peek_expect(If) {
         input.call_now(&[expr_atom_10])
     } else {
-        input.call_now(&[expr_atom_30])
+        input.call_now(&[expr_atom_33])
     }
 }
 fn expr_atom_9<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
@@ -3977,13 +3977,13 @@ fn expr_atom_10<Span: Copy>(
 ) -> Result<Transition<Span>, Option<Span>> {
     input.call_now(&[expr_atom_9])
 }
-fn expr_atom_30<Span: Copy>(
+fn expr_atom_33<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
     if input.peek_expect(LParen) {
         input.call_now(&[expr_atom_12])
     } else {
-        input.call_now(&[expr_atom_29])
+        input.call_now(&[expr_atom_32])
     }
 }
 fn expr_atom_11<Span: Copy>(
@@ -3996,13 +3996,13 @@ fn expr_atom_12<Span: Copy>(
 ) -> Result<Transition<Span>, Option<Span>> {
     input.call_now(&[expr_atom_11])
 }
-fn expr_atom_29<Span: Copy>(
+fn expr_atom_32<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
     if input.peek_expect(LBracket) {
         input.call_now(&[expr_atom_14])
     } else {
-        input.call_now(&[expr_atom_28])
+        input.call_now(&[expr_atom_31])
     }
 }
 fn expr_atom_13<Span: Copy>(
@@ -4015,13 +4015,13 @@ fn expr_atom_14<Span: Copy>(
 ) -> Result<Transition<Span>, Option<Span>> {
     input.call_now(&[expr_atom_13])
 }
-fn expr_atom_28<Span: Copy>(
+fn expr_atom_31<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
     if input.peek_expect(LBrace) {
         input.call_now(&[expr_atom_16])
     } else {
-        input.call_now(&[expr_atom_27])
+        input.call_now(&[expr_atom_30])
     }
 }
 fn expr_atom_15<Span: Copy>(
@@ -4034,13 +4034,13 @@ fn expr_atom_16<Span: Copy>(
 ) -> Result<Transition<Span>, Option<Span>> {
     input.call_now(&[expr_atom_15])
 }
-fn expr_atom_27<Span: Copy>(
+fn expr_atom_30<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
     if input.peek_expect(Loop) || input.peek_expect(FragmentLifetime) {
         input.call_now(&[expr_atom_18])
     } else {
-        input.call_now(&[expr_atom_26])
+        input.call_now(&[expr_atom_29])
     }
 }
 fn expr_atom_17<Span: Copy>(
@@ -4053,13 +4053,13 @@ fn expr_atom_18<Span: Copy>(
 ) -> Result<Transition<Span>, Option<Span>> {
     input.call_now(&[expr_atom_17])
 }
-fn expr_atom_26<Span: Copy>(
+fn expr_atom_29<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
     if input.peek_expect(While) {
         input.call_now(&[expr_atom_20])
     } else {
-        input.call_now(&[expr_atom_25])
+        input.call_now(&[expr_atom_28])
     }
 }
 fn expr_atom_19<Span: Copy>(
@@ -4072,13 +4072,13 @@ fn expr_atom_20<Span: Copy>(
 ) -> Result<Transition<Span>, Option<Span>> {
     input.call_now(&[expr_atom_19])
 }
-fn expr_atom_25<Span: Copy>(
+fn expr_atom_28<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
     if input.peek_expect(For) {
         input.call_now(&[expr_atom_22])
     } else {
-        input.call_now(&[expr_atom_24])
+        input.call_now(&[expr_atom_27])
     }
 }
 fn expr_atom_21<Span: Copy>(
@@ -4091,23 +4091,42 @@ fn expr_atom_22<Span: Copy>(
 ) -> Result<Transition<Span>, Option<Span>> {
     input.call_now(&[expr_atom_21])
 }
+fn expr_atom_27<Span: Copy>(
+    input: &mut RustParser<Span>,
+) -> Result<Transition<Span>, Option<Span>> {
+    if input.peek_expect(Match) {
+        input.call_now(&[expr_atom_24])
+    } else {
+        input.call_now(&[expr_atom_26])
+    }
+}
 fn expr_atom_23<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.error()
+    input.call_now(&[expr_match])
 }
 fn expr_atom_24<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
     input.call_now(&[expr_atom_23])
 }
-fn expr_atom_35<Span: Copy>(
+fn expr_atom_25<Span: Copy>(
     input: &mut RustParser<Span>,
 ) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[expr_atom_34])
+    input.error()
+}
+fn expr_atom_26<Span: Copy>(
+    input: &mut RustParser<Span>,
+) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[expr_atom_25])
+}
+fn expr_atom_38<Span: Copy>(
+    input: &mut RustParser<Span>,
+) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[expr_atom_37])
 }
 fn expr_atom<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
-    input.call_now(&[expr_atom_35])
+    input.call_now(&[expr_atom_38])
 }
 fn expr_return_or_break_2<Span: Copy>(
     input: &mut RustParser<Span>,
@@ -5578,6 +5597,122 @@ fn expr_for_5<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Spa
 }
 fn expr_for<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
     input.call_now(&[expr_for_5])
+}
+fn expr_match_0<Span: Copy>(
+    input: &mut RustParser<Span>,
+) -> Result<Transition<Span>, Option<Span>> {
+    input.bump_expect(RBrace, &[])
+}
+fn expr_match_1<Span: Copy>(
+    input: &mut RustParser<Span>,
+) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[match_arms])
+}
+fn expr_match_2<Span: Copy>(
+    input: &mut RustParser<Span>,
+) -> Result<Transition<Span>, Option<Span>> {
+    input.bump_expect(LBrace, &[])
+}
+fn expr_match_3<Span: Copy>(
+    input: &mut RustParser<Span>,
+) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[expr])
+}
+fn expr_match_4<Span: Copy>(
+    input: &mut RustParser<Span>,
+) -> Result<Transition<Span>, Option<Span>> {
+    input.bump_expect(Match, &[])
+}
+fn expr_match_5<Span: Copy>(
+    input: &mut RustParser<Span>,
+) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[
+        expr_match_0,
+        expr_match_1,
+        expr_match_2,
+        expr_match_3,
+        expr_match_4,
+    ])
+}
+fn expr_match<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[expr_match_5])
+}
+fn match_arms_4<Span: Copy>(
+    input: &mut RustParser<Span>,
+) -> Result<Transition<Span>, Option<Span>> {
+    if input.peek_expect(RBrace) {
+        input.call_now(&[match_arms_0])
+    } else {
+        input.call_now(&[match_arms_3])
+    }
+}
+fn match_arms_0<Span: Copy>(
+    input: &mut RustParser<Span>,
+) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[])
+}
+fn match_arms_1<Span: Copy>(
+    input: &mut RustParser<Span>,
+) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[match_arms])
+}
+fn match_arms_2<Span: Copy>(
+    input: &mut RustParser<Span>,
+) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[match_arm])
+}
+fn match_arms_3<Span: Copy>(
+    input: &mut RustParser<Span>,
+) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[match_arms_1, match_arms_2])
+}
+fn match_arms_5<Span: Copy>(
+    input: &mut RustParser<Span>,
+) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[match_arms_4])
+}
+fn match_arms<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[match_arms_5])
+}
+fn match_arm_0<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+    input.bump_expect(Comma, &[])
+}
+fn match_arm_1<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[expr])
+}
+fn match_arm_2<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+    input.bump_expect(FatArrow, &[])
+}
+fn match_arm_6<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+    if input.peek_expect(If) {
+        input.call_now(&[match_arm_5])
+    } else {
+        input.call_now(&[])
+    }
+}
+fn match_arm_3<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[expr])
+}
+fn match_arm_4<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+    input.bump_expect(If, &[])
+}
+fn match_arm_5<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[match_arm_3, match_arm_4])
+}
+fn match_arm_7<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[pat])
+}
+fn match_arm_8<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[
+        match_arm_0,
+        match_arm_1,
+        match_arm_2,
+        match_arm_6,
+        match_arm_7,
+    ])
+}
+fn match_arm<Span: Copy>(input: &mut RustParser<Span>) -> Result<Transition<Span>, Option<Span>> {
+    input.call_now(&[match_arm_8])
 }
 fn macro_call_tail_0<Span: Copy>(
     input: &mut RustParser<Span>,

--- a/rust-grammar-dpdfa/src/tests.rs
+++ b/rust-grammar-dpdfa/src/tests.rs
@@ -24,8 +24,8 @@ macro_rules! check_parse {
                 match parser.step(token, idx) {
                     Ok(_) => {},
 
-                    Err((idx, _)) => {
-                        panic!("Failed to parse token `{:?}` at index {}", token, idx);
+                    Err((idx, expected)) => {
+                        panic!("Failed to parse token `{:?}` at index {}. Expected {:?}", token, idx, expected);
                     }
                 }
             }
@@ -309,6 +309,18 @@ check_parse! {
             fn foo() {
                 loop {}
                 42
+            }
+        }
+    }
+}
+
+check_parse! {
+    fn match_arms_are_broken() {
+        expr,
+        {
+            match () {
+                () => {},
+                () => {},
             }
         }
     }

--- a/tests/ui/fail/expr-tuple.stderr
+++ b/tests/ui/fail/expr-tuple.stderr
@@ -1,10 +1,10 @@
-error: Potentially invalid expansion. Expected an expression, an identifier, `::`, `<`, `Self`, `break` or 13 others.
+error: Potentially invalid expansion. Expected an expression, an identifier, `::`, `<`, `Self`, `break` or 14 others.
  --> tests/ui/fail/expr-tuple.rs:6:10
   |
 6 |         (,)
   |          ^
 
-error: Potentially invalid expansion. Expected an expression, an identifier, `::`, `<`, `Self`, `break` or 13 others.
+error: Potentially invalid expansion. Expected an expression, an identifier, `::`, `<`, `Self`, `break` or 14 others.
   --> tests/ui/fail/expr-tuple.rs:13:13
    |
 13 |         (42,, 42)

--- a/tests/ui/fail/invalid_fn_calls.stderr
+++ b/tests/ui/fail/invalid_fn_calls.stderr
@@ -1,10 +1,10 @@
-error: Potentially invalid expansion. Expected an expression, an identifier, `::`, `<`, `Self`, `break` or 13 others.
+error: Potentially invalid expansion. Expected an expression, an identifier, `::`, `<`, `Self`, `break` or 14 others.
  --> tests/ui/fail/invalid_fn_calls.rs:6:18
   |
 6 |         $fn_name(,)
   |                  ^
 
-error: Potentially invalid expansion. Expected an expression, an identifier, `::`, `<`, `Self`, `break` or 13 others.
+error: Potentially invalid expansion. Expected an expression, an identifier, `::`, `<`, `Self`, `break` or 14 others.
   --> tests/ui/fail/invalid_fn_calls.rs:14:18
    |
 14 |         $fn_name(,,)

--- a/tests/ui/fail/js_concat.stderr
+++ b/tests/ui/fail/js_concat.stderr
@@ -1,4 +1,4 @@
-error: Potentially invalid expansion. Expected an expression, an identifier, `::`, `<`, `Self`, `break` or 12 others.
+error: Potentially invalid expansion. Expected an expression, an identifier, `::`, `<`, `Self`, `break` or 13 others.
  --> tests/ui/fail/js_concat.rs:5:16
   |
 5 |         $left ++ $right

--- a/tests/ui/fail/missing_expr.stderr
+++ b/tests/ui/fail/missing_expr.stderr
@@ -1,4 +1,4 @@
-error: Potentially invalid expansion. Expected an expression, an identifier, `::`, `<`, `Self`, `break` or 12 others.
+error: Potentially invalid expansion. Expected an expression, an identifier, `::`, `<`, `Self`, `break` or 13 others.
  --> tests/ui/fail/missing_expr.rs:6:17
   |
 6 |         let a = ;

--- a/tests/ui/fail/python_power_operator.stderr
+++ b/tests/ui/fail/python_power_operator.stderr
@@ -1,4 +1,4 @@
-error: Potentially invalid expansion. Expected an expression, an identifier, `::`, `<`, `Self`, `break` or 12 others.
+error: Potentially invalid expansion. Expected an expression, an identifier, `::`, `<`, `Self`, `break` or 13 others.
  --> tests/ui/fail/python_power_operator.rs:5:14
   |
 5 |         $e * *$e

--- a/tests/ui/pass/match-expr.rs
+++ b/tests/ui/pass/match-expr.rs
@@ -1,0 +1,17 @@
+#[allow(unused)]
+#[expandable::expr]
+#[rustfmt::skip]
+macro_rules! test {
+    ($e:expr, $p:pat) => {
+        match $e {
+            // TODO(scrabsha): add tests for match arms that don't end with `,`.
+            $p => $e,
+            () => {},
+            () if a != $e => {},
+            _ => 42,
+            _ | _ => 31,
+        }
+    };
+}
+
+fn main() {}


### PR DESCRIPTION
Title says everything.

Sadly the support is not as complete as I'd like it to be.

It turns out it's incredibly hard to guess if the operand is a block expression or not. This requires many refactorings that I'm too tired to do. The result is that the `,` is required at the end of the `match` arm, even if the operand is a block expression.

Part of #29.