### PR TITLE
fix: propagate "no repetitions" when checking 0-n repetitions

### DIFF
--- a/expandable-impl/src/expansion.rs
+++ b/expandable-impl/src/expansion.rs
@@ -343,7 +343,12 @@ where
         Id: Clone + Ord,
     {
         // Values accumulated during the previous iterations.
-        let mut outcomes = Set::new();
+        let mut outcomes = states
+            .iter()
+            .cloned()
+            .map(|(s, id)| (s, Transition::empty(), id))
+            .collect::<Set<_>>();
+
         let mut reached_transitions = Set::<Transition>::new();
         // Values discovered during the current iteration.
         let mut to_test: Set<(DynamicState<_>, (Transition, Id))> = states

--- a/expandable-impl/src/expansion.rs
+++ b/expandable-impl/src/expansion.rs
@@ -703,7 +703,7 @@ mod tests {
         expr_path_full_fragment {
             #[expr]
             ( #ident:ident ) => {
-                #( :: #ident )*
+                #( :: #ident )+
             }
         }
     }

--- a/expandable-impl/src/expansion.rs
+++ b/expandable-impl/src/expansion.rs
@@ -763,8 +763,6 @@ mod tests {
             };
             expect_test::expect![[r#"
                 [
-                    Literal,
-                    Plus,
                     Plus,
                     Ident,
                 ]

--- a/expandable-impl/src/grammar.rs
+++ b/expandable-impl/src/grammar.rs
@@ -58,8 +58,6 @@ where
         self.eaten
             .len()
             .cmp(&other.eaten.len())
-            .reverse() // TODO: this rev seem to be necessary. Otherwise, ExpCtx::parse_stream starts with the
-            // longest traces first, which is bad.
             .then_with(|| self.state.cmp(&other.state))
     }
 }
@@ -494,33 +492,5 @@ token_description! {
         Terminal::Dollar => Dollar,
         /// A question mark (`?`).
         Terminal::QuestionMark => QuestionMark,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn stupid_ordering_question() {
-        use TokenDescription::*;
-
-        let mut state_1 = DynamicState::expr();
-        // 42 + 42 +
-        let tokens = [Literal, Plus, Literal, Plus];
-
-        for token in tokens {
-            state_1 = state_1.accept(token, ()).unwrap().0;
-        }
-
-        let mut state_2 = DynamicState::expr();
-        // 42 +
-        let tokens = [Literal, Plus];
-
-        for token in tokens {
-            state_2 = state_2.accept(token, ()).unwrap().0;
-        }
-
-        assert!(state_1 < state_2);
     }
 }

--- a/expandable-impl/src/lib.rs
+++ b/expandable-impl/src/lib.rs
@@ -833,7 +833,7 @@ mod tests {
             #[expr]
             {
                 () => {
-                    #( :: a )*
+                    #( :: a )+
                 }
             }
         }
@@ -843,8 +843,8 @@ mod tests {
         path_repeat_from_fragment {
             #[expr]
             {
-                ( #( #id:ident )* ) => {
-                    #( :: #id )*
+                ( #( #id:ident )+ ) => {
+                    #( :: #id )+
                 }
             }
         }

--- a/tests/ui/pass/expr_path.rs
+++ b/tests/ui/pass/expr_path.rs
@@ -1,8 +1,8 @@
 #[allow(unused)]
 #[expandable::expr]
 macro_rules! test {
-    ( $( $ident:ident )* ) => {
-        $( :: $ident )*
+    ( $( $ident:ident )+ ) => {
+        $( :: $ident )+
     };
 
     () => {


### PR DESCRIPTION
Obligatory meme:

![megamind peeking meme "no repetitions?"](https://github.com/user-attachments/assets/6ee7deec-1931-43d8-ba5b-ae239eebd40b)

It occurred to me that the counterexample generated in the `cex_with_repetition` test could be shorter. While investigating, I found out this was because we forgot to propagate the states that correspond to "no repetitions" when checking for zero or more repetitions. This PR fixes this.

I also discovered that I wrote incorrect macro tests. Most notably, `$( :: $ident )*` is NOT a valid expression as far as `expandable` is concerned (0 repetitions means empty expansion, which is not a valid expression).