### PR TITLE
feat: add minimal support for the Lifetime token description

### DIFF
--- a/grammar-gen/src/codegen.rs
+++ b/grammar-gen/src/codegen.rs
@@ -552,8 +552,8 @@ impl GlobalCtxt {
     fn add_function(&mut self, name: String) {
         let id = self.fns.len().try_into().unwrap();
         let id = FunctionId(id);
-        let prev = self.fns.insert(name, id);
-        assert!(prev.is_none());
+        let prev = self.fns.insert(name.clone(), id);
+        assert!(prev.is_none(), "Redefinition of function `{name}`");
     }
 
     fn fn_id(&self, name: &str) -> FunctionId {
@@ -850,6 +850,7 @@ to_tokens_enum! {
     #[derive(Clone, Copy, Debug, PartialEq)]
     pub enum TokenDescription {
         Ident,
+        Lifetime,
         As,
         Async,
         Await,

--- a/rust-grammar-dpdfa/src/token.rs
+++ b/rust-grammar-dpdfa/src/token.rs
@@ -1,6 +1,7 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
 pub enum TokenDescription {
     Ident,
+    Lifetime,
     As,
     Async,
     Await,


### PR DESCRIPTION
For some reason, I completely forgot to add the Lifetime token description, which disabled me from writing parts of the parser.

This MR does the minimal amount of work on this side, and adds it in `grammar-gen` and in `rust-grammar-dpdfa`. I don't think the lifetime is correctly parsed in the frontend. This will be done later, in another PR :sparkles:.