### PR TITLE
fix: add `repository` field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 version = "0.1.1"
 rust-version = "1.70.0"
+repository = "https://github.com/scrabsha/expandable"
 
 [workspace.dependencies]
 # MSRV: 1.70 (checked in CI)
@@ -28,7 +29,7 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
-repository = "https://github.com/scrabsha/expandable"
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
+repository = "https://github.com/scrabsha/expandable"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/expandable-impl/Cargo.toml
+++ b/expandable-impl/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [dependencies]
 # MSRV: 1.36 (checked in CI)

--- a/rust-grammar-dpdfa/Cargo.toml
+++ b/rust-grammar-dpdfa/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
To make the repository easier to find. Apologies if this field was omitted intentionally.