### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/scrabsha/expandable/compare/expandable-v0.1.1...expandable-v0.1.2) - 2024-10-26
+
+### Fixed
+
+- add `repository` field to Cargo.toml ([#79](https://github.com/scrabsha/expandable/pull/79))
+
 ## [0.1.1](https://github.com/scrabsha/expandable/compare/expandable-v0.1.0...expandable-v0.1.1) - 2024-10-20
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,15 @@ members = [
 [workspace.package]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-version = "0.1.1"
+version = "0.1.2"
 rust-version = "1.70.0"
 repository = "https://github.com/scrabsha/expandable"
 
 [workspace.dependencies]
 # MSRV: 1.70 (checked in CI)
-expandable-impl = { path = "expandable-impl", version = "0.1.1" }
+expandable-impl = { path = "expandable-impl", version = "0.1.2" }
 # MSRV: 1.70 (checked in CI)
-rust-grammar-dpdfa = { path = "rust-grammar-dpdfa", version = "0.1.1" }
+rust-grammar-dpdfa = { path = "rust-grammar-dpdfa", version = "0.1.2" }
 
 [package]
 name = "expandable"

--- a/expandable-impl/CHANGELOG.md
+++ b/expandable-impl/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/scrabsha/expandable/compare/expandable-impl-v0.1.1...expandable-impl-v0.1.2) - 2024-10-26
+
+### Fixed
+
+- add `repository` field to Cargo.toml ([#79](https://github.com/scrabsha/expandable/pull/79))
+
 ## [0.1.1](https://github.com/scrabsha/expandable/compare/expandable-impl-v0.1.0...expandable-impl-v0.1.1) - 2024-10-20
 
 ### Added

--- a/rust-grammar-dpdfa/CHANGELOG.md
+++ b/rust-grammar-dpdfa/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/scrabsha/expandable/compare/rust-grammar-dpdfa-v0.1.1...rust-grammar-dpdfa-v0.1.2) - 2024-10-26
+
+### Fixed
+
+- add `repository` field to Cargo.toml ([#79](https://github.com/scrabsha/expandable/pull/79))
+
 ## [0.1.1](https://github.com/scrabsha/expandable/compare/rust-grammar-dpdfa-v0.1.0...rust-grammar-dpdfa-v0.1.1) - 2024-10-20
 
 ### Fixed


### PR DESCRIPTION
## 🤖 New release
* `expandable`: 0.1.1 -> 0.1.2
* `expandable-impl`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `rust-grammar-dpdfa`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `expandable`
<blockquote>

## [0.1.2](https://github.com/scrabsha/expandable/compare/expandable-v0.1.1...expandable-v0.1.2) - 2024-10-26

### Fixed

- add `repository` field to Cargo.toml ([#79](https://github.com/scrabsha/expandable/pull/79))
</blockquote>

## `expandable-impl`
<blockquote>

## [0.1.2](https://github.com/scrabsha/expandable/compare/expandable-impl-v0.1.1...expandable-impl-v0.1.2) - 2024-10-26

### Fixed

- add `repository` field to Cargo.toml ([#79](https://github.com/scrabsha/expandable/pull/79))
</blockquote>

## `rust-grammar-dpdfa`
<blockquote>

## [0.1.2](https://github.com/scrabsha/expandable/compare/rust-grammar-dpdfa-v0.1.1...rust-grammar-dpdfa-v0.1.2) - 2024-10-26

### Fixed

- add `repository` field to Cargo.toml ([#79](https://github.com/scrabsha/expandable/pull/79))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).